### PR TITLE
Use 'momo-panel-mapcontainer' xtype for MapModule

### DIFF
--- a/src/main/resources/META-INF/spring/dev/momo-context-initialize-beans.xml
+++ b/src/main/resources/META-INF/spring/dev/momo-context-initialize-beans.xml
@@ -145,7 +145,6 @@
     <bean id="borderLayout" class="de.terrestris.shogun2.model.layout.BorderLayout">
         <property name="propertyHints">
             <util:set id="propertyHints">
-                <value>title</value>
                 <value>collapsible</value>
                 <value>split</value>
             </util:set>
@@ -429,7 +428,7 @@
     <!-- Define the Map -->
     <bean id="mapModule" class="de.terrestris.shogun2.model.module.Map">
         <property name="name" value="Main Map" />
-        <property name="xtype" value="momo-component-map" />
+        <property name="xtype" value="momo-panel-mapcontainer" />
         <property name="mapConfig" ref="mapConfig" />
         <property name="mapLayers">
             <util:list>
@@ -449,6 +448,8 @@
         <property name="properties">
             <util:map>
                 <entry key="region" value="center" />
+                <entry key="collapsible" value="false" />
+                <entry key="split" value="true" />
             </util:map>
         </property>
     </bean>
@@ -486,6 +487,8 @@
         <property name="properties">
             <util:map>
                 <entry key="region" value="north" />
+                <entry key="collapsible" value="false" />
+                <entry key="split" value="true" />
                 <entry key="height" value="120" />
                 <entry key="bodyStyle" value="background:#5FA2DD;" />
             </util:map>


### PR DESCRIPTION
Changed xtype of `mapModule` since we use a `BasiGX.view.panel.MapContainer` in frontend.

This MR must be merged after https://github.com/terrestris/momo3-frontend/pull/4 was merged.
