### PR TITLE
Adapt project to use SHOGun 0.0.6 release version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <!-- The type of connection to use (connection or developerConnection) -->
         <maven-scm-plugin.connection-type>developerConnection</maven-scm-plugin.connection-type>
 
-        <shogun2.version>0.0.6-SNAPSHOT</shogun2.version>
+        <shogun2.version>0.0.6</shogun2.version>
 
         <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
         <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>

--- a/src/main/java/de/terrestris/momo/model/ProjectApplication.java
+++ b/src/main/java/de/terrestris/momo/model/ProjectApplication.java
@@ -3,8 +3,6 @@ package de.terrestris.momo.model;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 
-import ch.rasc.extclassgenerator.Model;
-
 import de.terrestris.shogun2.model.Application;
 
 /**
@@ -14,11 +12,6 @@ import de.terrestris.shogun2.model.Application;
  *
  */
 @Entity
-@Model(value = "momo.model.ProjectApplication",
-	readMethod = "projectApplicationService.findWithSortingAndPagingExtDirect",
-	createMethod = "projectApplicationService.saveOrUpdateCollection",
-	updateMethod = "projectApplicationService.saveOrUpdateCollection",
-	destroyMethod = "projectApplicationService.deleteCollection")
 public class ProjectApplication extends Application {
 
 	private static final long serialVersionUID = 1L;

--- a/src/main/resources/META-INF/config/ci/geoServerNameSpaces.properties
+++ b/src/main/resources/META-INF/config/ci/geoServerNameSpaces.properties
@@ -1,0 +1,1 @@
+momo=http://URL:8080/geoserver/momo/ows

--- a/src/main/resources/META-INF/config/dev/geoServerNameSpaces.properties
+++ b/src/main/resources/META-INF/config/dev/geoServerNameSpaces.properties
@@ -1,0 +1,1 @@
+momo=http://URL:8080/geoserver/momo/ows

--- a/src/main/resources/META-INF/config/prod/geoServerNameSpaces.properties
+++ b/src/main/resources/META-INF/config/prod/geoServerNameSpaces.properties
@@ -1,0 +1,1 @@
+momo=http://URL:8080/geoserver/momo/ows

--- a/src/main/resources/META-INF/spring/momo-context.xml
+++ b/src/main/resources/META-INF/spring/momo-context.xml
@@ -2,27 +2,21 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:util="http://www.springframework.org/schema/util"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
                            http://www.springframework.org/schema/beans/spring-beans.xsd
                            http://www.springframework.org/schema/context
-                           http://www.springframework.org/schema/context/spring-context.xsd">
+                           http://www.springframework.org/schema/context/spring-context.xsd
+                           http://www.springframework.org/schema/util
+                           http://www.springframework.org/schema/util/spring-util.xsd">
 
     <context:property-placeholder location="classpath*:META-INF/config/${app.profile}/*.properties" />
 
-    <context:component-scan base-package="de.terrestris, ch.ralscha.extdirectspring">
+    <context:component-scan base-package="de.terrestris">
         <context:exclude-filter
             expression="org.springframework.stereotype.Controller" type="annotation" />
     </context:component-scan>
-
-    <bean id="modelPackageCandidates" class="java.util.ArrayList">
-        <constructor-arg>
-            <list>
-                <value type="java.lang.String">de.terrestris.shogun2.model</value>
-                <value type="java.lang.String">de.terrestris.momo.model</value>
-            </list>
-        </constructor-arg>
-    </bean>
 
     <!-- The mailSender configuration -->
     <bean id="mailSender" class="org.springframework.mail.javamail.JavaMailSenderImpl">
@@ -62,5 +56,8 @@
     <bean id="changePasswordPath" class="java.lang.String">
         <constructor-arg value="${login.changePasswordPath}"></constructor-arg>
     </bean>
+
+    <!-- The GeoServer Namespace to URI map used in the Interceptor -->
+    <util:properties id="geoServerNameSpaces" location="classpath*:META-INF/config/${app.profile}/geoServerNameSpaces.properties" />
 
 </beans>

--- a/src/main/webapp/WEB-INF/log4j.properties
+++ b/src/main/webapp/WEB-INF/log4j.properties
@@ -34,9 +34,6 @@ log4j.logger.org.hibernate=INFO
 # configure the c3p0 logging
 log4j.logger.com.mchange.v2=INFO
 
-# configure the extdirectspring logging
-log4j.logger.ch.ralscha.extdirectspring=INFO
-
 ### log HQL query parser activity
 #log4j.logger.org.hibernate.hql.ast.AST=debug
 

--- a/src/main/webapp/WEB-INF/momo-servlet.xml
+++ b/src/main/webapp/WEB-INF/momo-servlet.xml
@@ -37,8 +37,7 @@
     <beans:bean id="jacksonObjectMapper"
         class="de.terrestris.shogun2.util.json.Shogun2JsonObjectMapper" />
 
-    <component-scan base-package="de.terrestris.*.rest,
- de.terrestris.*.web, de.terrestris.momo.web, ch.ralscha.extdirectspring"
+    <component-scan base-package="de.terrestris.*.rest, de.terrestris.*.web"
         use-default-filters="false">
         <include-filter expression="org.springframework.stereotype.Controller"
             type="annotation" />

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -44,13 +44,6 @@
         <url-pattern>/rest/*</url-pattern>
     </servlet-mapping>
 
-    <!-- Needed for the Ext Direct api.js.
-         See https://github.com/ralscha/extdirectspring/wiki/Api -->
-    <servlet-mapping>
-        <servlet-name>momo</servlet-name>
-        <url-pattern>/action/*</url-pattern>
-    </servlet-mapping>
-
     <!-- See de.terrestris.shogun2.web.ExtModelController -->
     <servlet-mapping>
         <servlet-name>momo</servlet-name>

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -5,10 +5,6 @@
 
 <!-- INCLUDE EXT LIB HERE -->
 
-<!-- EXT DIRECT
-    see https://github.com/ralscha/extdirectspring/wiki/Api -->
-<script type="text/javascript" src="action/api.js"></script>
-
 <!-- INCLUDE YOUR EXT APP (JS) HERE -->
 </head>
 


### PR DESCRIPTION
Until now, the project was running on (some!?) SNAPSHOT version of SHOGun2.

This PR adapts the project to make use of the release version 0.0.6 that is published on maven central.
