### PR TITLE
Create applications

### DIFF
--- a/src/main/java/de/terrestris/momo/dto/ApplicationData.java
+++ b/src/main/java/de/terrestris/momo/dto/ApplicationData.java
@@ -1,0 +1,144 @@
+package de.terrestris.momo.dto;
+
+import java.awt.geom.Point2D;
+
+/**
+ *
+ * A class to encapsulate the relevant data of an application (e.g. when it is
+ * being created) in a simple/flat way for (JSON-based) exchange between front- and backend.
+ *
+ * @author Nils Bühner
+ *
+ */
+public class ApplicationData {
+
+	private String name;
+	private String description;
+	private String language;
+	private Boolean isPublic;
+	private Boolean isActive;
+	private String projection;
+	private Point2D.Double center;
+	private Integer zoom;
+
+	/**
+	 *
+	 */
+	public ApplicationData() {
+
+	}
+
+	/**
+	 * @return the name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * @param name the name to set
+	 */
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	/**
+	 * @return the description
+	 */
+	public String getDescription() {
+		return description;
+	}
+
+	/**
+	 * @param description the description to set
+	 */
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	/**
+	 * @return the language
+	 */
+	public String getLanguage() {
+		return language;
+	}
+
+	/**
+	 * @param language the language to set
+	 */
+	public void setLanguage(String language) {
+		this.language = language;
+	}
+
+	/**
+	 * @return the isPublic
+	 */
+	public Boolean getIsPublic() {
+		return isPublic;
+	}
+
+	/**
+	 * @param isPublic the isPublic to set
+	 */
+	public void setIsPublic(Boolean isPublic) {
+		this.isPublic = isPublic;
+	}
+
+	/**
+	 * @return the isActive
+	 */
+	public Boolean getIsActive() {
+		return isActive;
+	}
+
+	/**
+	 * @param isActive the isActive to set
+	 */
+	public void setIsActive(Boolean isActive) {
+		this.isActive = isActive;
+	}
+
+	/**
+	 * @return the projection
+	 */
+	public String getProjection() {
+		return projection;
+	}
+
+	/**
+	 * @param projection the projection to set
+	 */
+	public void setProjection(String projection) {
+		this.projection = projection;
+	}
+
+	/**
+	 * @return the center
+	 */
+	public Point2D.Double getCenter() {
+		return center;
+	}
+
+	/**
+	 * @param center the center to set
+	 */
+	public void setCenter(Point2D.Double center) {
+		this.center = center;
+	}
+
+	/**
+	 * @return the zoom
+	 */
+	public Integer getZoom() {
+		return zoom;
+	}
+
+	/**
+	 * @param zoom the zoom to set
+	 */
+	public void setZoom(Integer zoom) {
+		this.zoom = zoom;
+	}
+
+
+}

--- a/src/main/java/de/terrestris/momo/service/MomoApplicationService.java
+++ b/src/main/java/de/terrestris/momo/service/MomoApplicationService.java
@@ -1,0 +1,279 @@
+package de.terrestris.momo.service;
+
+import java.awt.geom.Point2D;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import org.hibernate.criterion.Criterion;
+import org.hibernate.criterion.Restrictions;
+import org.hibernate.criterion.SimpleExpression;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationContext;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+
+import de.terrestris.momo.dto.ApplicationData;
+import de.terrestris.shogun2.dao.ApplicationDao;
+import de.terrestris.shogun2.dao.ExtentDao;
+import de.terrestris.shogun2.dao.LayerDao;
+import de.terrestris.shogun2.dao.LayoutDao;
+import de.terrestris.shogun2.dao.MapConfigDao;
+import de.terrestris.shogun2.dao.MapControlDao;
+import de.terrestris.shogun2.dao.MapDao;
+import de.terrestris.shogun2.dao.ModuleDao;
+import de.terrestris.shogun2.dao.UserDao;
+import de.terrestris.shogun2.model.Application;
+import de.terrestris.shogun2.model.User;
+import de.terrestris.shogun2.model.layer.Layer;
+import de.terrestris.shogun2.model.layer.util.Extent;
+import de.terrestris.shogun2.model.layout.Layout;
+import de.terrestris.shogun2.model.map.MapConfig;
+import de.terrestris.shogun2.model.map.MapControl;
+import de.terrestris.shogun2.model.module.CompositeModule;
+import de.terrestris.shogun2.model.module.Map;
+import de.terrestris.shogun2.model.module.Module;
+import de.terrestris.shogun2.model.security.Permission;
+import de.terrestris.shogun2.service.ApplicationService;
+import de.terrestris.shogun2.service.ExtentService;
+import de.terrestris.shogun2.service.LayerService;
+import de.terrestris.shogun2.service.LayoutService;
+import de.terrestris.shogun2.service.MapConfigService;
+import de.terrestris.shogun2.service.MapControlService;
+import de.terrestris.shogun2.service.MapService;
+import de.terrestris.shogun2.service.ModuleService;
+import de.terrestris.shogun2.service.UserService;
+
+/**
+ *
+ * @author Nils Bühner
+ * @see ApplicationService
+ *
+ */
+@Service("momoApplicationService")
+public class MomoApplicationService<E extends Application, D extends ApplicationDao<E>>
+		extends ApplicationService<E, D> {
+
+	private static final String BEAN_ID_DEFAULT_MAP = "defaultMap";
+
+	private static final String BEAN_ID_DEFAULT_MAP_CONTAINER = "defaultMapContainer";
+
+	private static final String BEAN_ID_DEFAULT_MAX_EXTENT = "defaultMaxExtent";
+
+	private static final String BEAN_ID_DEFAULT_RESOLUTIONS = "defaultResolutions";
+
+	private static final String BEAN_ID_MAX_RES = "res19";
+
+	private static final String BEAN_ID_MIN_RES = "res01";
+
+	private static final Set<String> DEFAULT_MAP_CONTROLS = Collections.unmodifiableSet(
+			new HashSet<String>(Arrays.asList("Attribution", "Zoom", "Rotate", "ScaleLine", "ZoomSlider")));
+
+	private static final List<String> DEFAULT_MAP_CONTAINER_MODULES = Collections.unmodifiableList(Arrays
+			.asList("Show meta toolbar button", "Meta info toolbar for the map", "Tools Toolbar", "Gazetteer Grid"));
+
+	private static final List<String> DEFAULT_VIEWPORT_MODULES = Collections
+			.unmodifiableList(Arrays.asList("Viewport Header", "Legend Tree", "Gazetteer Grid"));
+
+	@Autowired
+	private ApplicationContext applicationContext;
+
+	@Autowired
+	@Qualifier("moduleService")
+	private ModuleService<Module, ModuleDao<Module>> moduleService;
+
+	@Autowired
+	@Qualifier("mapConfigService")
+	private MapConfigService<MapConfig, MapConfigDao<MapConfig>> mapConfigService;
+
+	@Autowired
+	@Qualifier("mapService")
+	private MapService<Map, MapDao<Map>> mapService;
+
+	@Autowired
+	@Qualifier("layoutService")
+	private LayoutService<Layout, LayoutDao<Layout>> layoutService;
+
+	@Autowired
+	@Qualifier("extentService")
+	private ExtentService<Extent, ExtentDao<Extent>> extentService;
+
+	@Autowired
+	@Qualifier("mapControlService")
+	private MapControlService<MapControl, MapControlDao<MapControl>> mapControlService;
+
+	@Autowired
+	@Qualifier("layerService")
+	private LayerService<Layer, LayerDao<Layer>> layerService;
+
+	@Autowired
+	@Qualifier("userService")
+	private UserService<User, UserDao<User>> userService;
+
+	/**
+	 *
+	 * @param isActive
+	 * @param isPublic
+	 * @param language
+	 * @return
+	 * @throws Exception
+	 * @throws InvocationTargetException
+	 */
+	@SuppressWarnings("unchecked")
+	@PreAuthorize("hasRole(@configHolder.getSuperAdminRoleName())")
+	public Application createMomoApplication(ApplicationData applicationData) throws Exception {
+
+		String name = applicationData.getName();
+		String description = applicationData.getDescription();
+		String language = applicationData.getLanguage();
+		Boolean isPublic = applicationData.getIsPublic();
+		Boolean isActive = applicationData.getIsActive();
+
+		String projection = applicationData.getProjection();
+		Point2D.Double center = applicationData.getCenter();
+		Integer zoom = applicationData.getZoom();
+
+		// create a new application
+		Application application = new Application(name, description);
+
+		// set properties
+		application.setLanguage(Locale.forLanguageTag(language));
+		application.setOpen(isPublic);
+		application.setActive(isActive);
+
+		// 1. map config
+		MapConfig mapConfig = buildMapConfig(projection, center, zoom);
+
+		// 2. map
+		Map map = buildMapModule(mapConfig);
+
+		// 3. map container
+		CompositeModule mapContainer = buildMapContainer(map);
+
+		// 4. viewport
+		CompositeModule viewport = buildViewport(mapContainer);
+
+		// 5. finalize...
+		application.setViewport(viewport);
+		dao.saveOrUpdate((E) application);
+
+		// grant admins rights to current user
+		User currentUser = userService.getUserBySession();
+		addAndSaveUserPermissions((E) application, currentUser, Permission.ADMIN);
+
+		return application;
+	}
+
+	/**
+	 * @param mapContainer
+	 * @return
+	 */
+	private CompositeModule buildViewport(CompositeModule mapContainer) {
+		CompositeModule viewport = new CompositeModule();
+		viewport.setXtype("viewport");
+
+		// get layout
+		final SimpleExpression isBorderLayout = Restrictions.eq("type", "border");
+		final Layout borderLayout = layoutService.getDao().findByUniqueCriteria(isBorderLayout);
+
+		// submodules
+		List<Module> vpSubModules = new ArrayList<Module>();
+		vpSubModules.add(mapContainer); //add the map
+		final ModuleDao<Module> moduleDao = moduleService.getDao();
+
+		for (String moduleName : DEFAULT_VIEWPORT_MODULES) {
+			Criterion hasModuleName = Restrictions.eq("name", moduleName);
+			vpSubModules.add(moduleDao.findByUniqueCriteria(hasModuleName));
+		}
+
+		viewport.setLayout(borderLayout);
+		viewport.setSubModules(vpSubModules);
+
+		moduleService.saveOrUpdate(viewport);
+		return viewport;
+	}
+
+	/**
+	 * @param map
+	 * @return
+	 */
+	private CompositeModule buildMapContainer(Map map) {
+		CompositeModule mapContainer = (CompositeModule) applicationContext.getBean(BEAN_ID_DEFAULT_MAP_CONTAINER);
+
+		// get layout
+		final SimpleExpression isAbsoluteLayout = Restrictions.eq("type", "absolute");
+		final Layout absoluteLayout = layoutService.getDao().findByUniqueCriteria(isAbsoluteLayout);
+
+		// submodules
+		List<Module> mcSubModules = new ArrayList<Module>();
+		mcSubModules.add(map); //add the map
+
+		final ModuleDao<Module> moduleDao = moduleService.getDao();
+
+		// add in correct order
+		for (String moduleName : DEFAULT_MAP_CONTAINER_MODULES) {
+			Criterion hasModuleName = Restrictions.eq("name", moduleName);
+			mcSubModules.add(moduleDao.findByUniqueCriteria(hasModuleName));
+		}
+
+		mapContainer.setLayout(absoluteLayout);
+		mapContainer.setSubModules(mcSubModules);
+
+		moduleService.saveOrUpdate(mapContainer);
+		return mapContainer;
+	}
+
+	/**
+	 * @param mapConfig
+	 * @return
+	 */
+	private Map buildMapModule(MapConfig mapConfig) {
+		Map map = (Map) applicationContext.getBean(BEAN_ID_DEFAULT_MAP);
+		map.setMapConfig(mapConfig);
+
+		final Criterion areDefaultMapControl = Restrictions.in("mapControlName", DEFAULT_MAP_CONTROLS);
+		final Set<MapControl> mapControls = new HashSet<MapControl>(
+				mapControlService.getDao().findByCriteria(areDefaultMapControl));
+		map.setMapControls(mapControls);
+
+		mapService.saveOrUpdate(map);
+		return map;
+	}
+
+	/**
+	 * @param projection
+	 * @param center
+	 * @param zoom
+	 * @return
+	 */
+	@SuppressWarnings("unchecked")
+	private MapConfig buildMapConfig(String projection, Point2D.Double center, Integer zoom) {
+		MapConfig mapConfig = new MapConfig();
+		mapConfig.setRotation(0.0);
+		mapConfig.setCenter(center);
+		mapConfig.setProjection(projection.replace("EPSG:", ""));
+		mapConfig.setZoom(zoom);
+
+		// set values from default map config
+		// TODO: become more dynamic, e.g. when another projection is used
+		mapConfig.setMinResolution((Double) applicationContext.getBean(BEAN_ID_MIN_RES));
+		mapConfig.setMaxResolution((Double) applicationContext.getBean(BEAN_ID_MAX_RES));
+		mapConfig.setResolutions((List<Double>) applicationContext.getBean(BEAN_ID_DEFAULT_RESOLUTIONS));
+
+		// TODO let the user configure this extent
+		Extent maxExtent = (Extent) applicationContext.getBean(BEAN_ID_DEFAULT_MAX_EXTENT);
+		extentService.saveOrUpdate(maxExtent);
+
+		mapConfig.setExtent(maxExtent);
+
+		mapConfigService.saveOrUpdate(mapConfig);
+		return mapConfig;
+	}
+
+}

--- a/src/main/java/de/terrestris/momo/web/MomoApplicationController.java
+++ b/src/main/java/de/terrestris/momo/web/MomoApplicationController.java
@@ -1,0 +1,75 @@
+package de.terrestris.momo.web;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import de.terrestris.momo.dto.ApplicationData;
+import de.terrestris.momo.service.MomoApplicationService;
+import de.terrestris.shogun2.dao.ApplicationDao;
+import de.terrestris.shogun2.model.Application;
+import de.terrestris.shogun2.web.ApplicationController;
+
+/**
+ * @author Kai Volland
+ * @author Nils Bühner
+ *
+ */
+@Controller
+@RequestMapping("/apps")
+public class MomoApplicationController<E extends Application, D extends ApplicationDao<E>, S extends MomoApplicationService<E, D>>
+		extends ApplicationController<E, D, S> {
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public MomoApplicationController() {
+		this((Class<E>) Application.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the controller.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected MomoApplicationController(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * We have to use {@link Qualifier} to define the correct service here.
+	 * Otherwise, spring can not decide which service has to be autowired here
+	 * as there are multiple candidates.
+	 */
+	@Override
+	@Autowired
+	@Qualifier("momoApplicationService")
+	public void setService(S service) {
+		this.service = service;
+	}
+
+	/**
+	 *
+	 * @param name
+	 * @return
+	 */
+	@SuppressWarnings("unchecked")
+	@RequestMapping(value="create.action", method = RequestMethod.POST)
+	public ResponseEntity<E> createMomoApplication(@RequestBody ApplicationData applicationData) {
+
+		E app = null;
+		try {
+			app = (E) service.createMomoApplication(applicationData);
+
+		} catch (Exception e) {
+			LOG.error("Could not create MOMO application: " + e.getMessage());
+		}
+		return new ResponseEntity<E>(app, HttpStatus.OK);
+	}
+
+}

--- a/src/main/java/de/terrestris/momo/web/MomoApplicationController.java
+++ b/src/main/java/de/terrestris/momo/web/MomoApplicationController.java
@@ -13,6 +13,7 @@ import de.terrestris.momo.dto.ApplicationData;
 import de.terrestris.momo.service.MomoApplicationService;
 import de.terrestris.shogun2.dao.ApplicationDao;
 import de.terrestris.shogun2.model.Application;
+import de.terrestris.shogun2.util.data.ResultSet;
 import de.terrestris.shogun2.web.ApplicationController;
 
 /**
@@ -60,16 +61,17 @@ public class MomoApplicationController<E extends Application, D extends Applicat
 	 */
 	@SuppressWarnings("unchecked")
 	@RequestMapping(value="create.action", method = RequestMethod.POST)
-	public ResponseEntity<E> createMomoApplication(@RequestBody ApplicationData applicationData) {
+	public ResponseEntity<?> createMomoApplication(@RequestBody ApplicationData applicationData) {
 
 		E app = null;
 		try {
 			app = (E) service.createMomoApplication(applicationData);
-
 		} catch (Exception e) {
-			LOG.error("Could not create MOMO application: " + e.getMessage());
+			final String msg = e.getMessage();
+			LOG.error("Could not create MOMO application: " + msg);
+			return new ResponseEntity<>(ResultSet.error(msg), HttpStatus.INTERNAL_SERVER_ERROR);
 		}
-		return new ResponseEntity<E>(app, HttpStatus.OK);
+		return new ResponseEntity<E>(app, HttpStatus.CREATED);
 	}
 
 }

--- a/src/main/resources/META-INF/spring/ci/momo-context-initialize-beans.xml
+++ b/src/main/resources/META-INF/spring/ci/momo-context-initialize-beans.xml
@@ -274,6 +274,8 @@
         <ref bean="zoomToExtentModule" />
         <ref bean="stepBackModule" />
         <ref bean="stepForwardModule" />
+        <ref bean="showMeasureToolsModule" />
+        <ref bean="showRedliningToolsModule" />
 
         <ref bean="showMetaToolbarModule" />
         <ref bean="metaToolbarModule" />
@@ -453,66 +455,7 @@
         </property>
     </bean>
 
-    <!-- The Resolutions -->
-    <bean id="res01" class="java.lang.Double">
-        <constructor-arg value="156543.03390625"></constructor-arg>
-    </bean>
-    <bean id="res02" class="java.lang.Double">
-        <constructor-arg value="78271.516953125"></constructor-arg>
-    </bean>
-    <bean id="res03" class="java.lang.Double">
-        <constructor-arg value="39135.7584765625"></constructor-arg>
-    </bean>
-    <bean id="res04" class="java.lang.Double">
-        <constructor-arg value="19567.87923828125"></constructor-arg>
-    </bean>
-    <bean id="res05" class="java.lang.Double">
-        <constructor-arg value="9783.939619140625"></constructor-arg>
-    </bean>
-    <bean id="res06" class="java.lang.Double">
-        <constructor-arg value="4891.9698095703125"></constructor-arg>
-    </bean>
-    <bean id="res07" class="java.lang.Double">
-        <constructor-arg value="2445.9849047851562"></constructor-arg>
-    </bean>
-    <bean id="res08" class="java.lang.Double">
-        <constructor-arg value="1222.9924523925781"></constructor-arg>
-    </bean>
-    <bean id="res09" class="java.lang.Double">
-        <constructor-arg value="611.4962261962891"></constructor-arg>
-    </bean>
-    <bean id="res10" class="java.lang.Double">
-        <constructor-arg value="305.74811309814453"></constructor-arg>
-    </bean>
-    <bean id="res11" class="java.lang.Double">
-        <constructor-arg value="152.87405654907226"></constructor-arg>
-    </bean>
-    <bean id="res12" class="java.lang.Double">
-        <constructor-arg value="76.43702827453613"></constructor-arg>
-    </bean>
-    <bean id="res13" class="java.lang.Double">
-        <constructor-arg value="38.218514137268066"></constructor-arg>
-    </bean>
-    <bean id="res14" class="java.lang.Double">
-        <constructor-arg value="19.109257068634033"></constructor-arg>
-    </bean>
-    <bean id="res15" class="java.lang.Double">
-        <constructor-arg value="9.554628534317017"></constructor-arg>
-    </bean>
-    <bean id="res16" class="java.lang.Double">
-        <constructor-arg value="4.777314267158508"></constructor-arg>
-    </bean>
-    <bean id="res17" class="java.lang.Double">
-        <constructor-arg value="2.388657133579254"></constructor-arg>
-    </bean>
-    <bean id="res18" class="java.lang.Double">
-        <constructor-arg value="1.194328566789627"></constructor-arg>
-    </bean>
-    <bean id="res19" class="java.lang.Double">
-        <constructor-arg value="0.5971642833948135"></constructor-arg>
-    </bean>
-
-    <!-- Default extent -->
+    <!-- Extent -->
     <bean id="mapConfigExtent" class="de.terrestris.shogun2.model.layer.util.Extent">
         <property name="lowerLeft">
             <bean class="java.awt.geom.Point2D$Double">
@@ -539,29 +482,7 @@
         </property>
         <property name="minResolution" ref="res01" />
         <property name="maxResolution" ref="res19" />
-        <property name="resolutions">
-            <util:list>
-                <ref bean="res01" />
-                <ref bean="res02" />
-                <ref bean="res03" />
-                <ref bean="res04" />
-                <ref bean="res05" />
-                <ref bean="res06" />
-                <ref bean="res07" />
-                <ref bean="res08" />
-                <ref bean="res09" />
-                <ref bean="res10" />
-                <ref bean="res11" />
-                <ref bean="res12" />
-                <ref bean="res13" />
-                <ref bean="res14" />
-                <ref bean="res15" />
-                <ref bean="res16" />
-                <ref bean="res17" />
-                <ref bean="res18" />
-                <ref bean="res19" />
-            </util:list>
-        </property>
+        <property name="resolutions" ref="defaultResolutions" />
         <property name="extent">
             <ref bean="mapConfigExtent" />
         </property>
@@ -6363,6 +6284,28 @@
         </property>
     </bean>
 
+    <bean id="showMeasureToolsModule" class="de.terrestris.shogun2.model.module.Button">
+        <property name="name" value="Show measure tools button" />
+        <property name="xtype" value="momo-button-showmeasuretoolspanel" />
+        <property name="properties">
+             <util:map>
+                <entry key="scale" value="small" />
+                <entry key="ui" value="default" />
+             </util:map>
+        </property>
+    </bean>
+
+    <bean id="showRedliningToolsModule" class="de.terrestris.shogun2.model.module.Button">
+        <property name="name" value="Show redlining tools button" />
+        <property name="xtype" value="momo-button-showredliningtoolspanel" />
+        <property name="properties">
+             <util:map>
+                <entry key="scale" value="small" />
+                <entry key="ui" value="default" />
+             </util:map>
+        </property>
+    </bean>
+
     <bean id="showMetaToolbarModule" class="de.terrestris.shogun2.model.module.Button">
         <property name="name" value="Show meta toolbar button" />
         <property name="xtype" value="momo-button-showmetapanel" />
@@ -6399,6 +6342,8 @@
                 <ref bean="zoomToExtentModule" />
                 <ref bean="stepBackModule" />
                 <ref bean="stepForwardModule" />
+                <ref bean="showMeasureToolsModule" />
+                <ref bean="showRedliningToolsModule" />
             </util:list>
         </property>
     </bean>
@@ -6695,4 +6640,146 @@
         <property name="expanded" value="true"/>
         <property name="root" value="true"/>
     </bean>
+
+
+    <!-- ******************************************************************* -->
+    <!-- ******************************************************************* -->
+    <!-- **************************  TEMPLATES  **************************** -->
+    <!-- ******************************************************************* -->
+    <!-- ******************************************************************* -->
+
+    <!-- The following beans are templates (usually with scope=prototype)
+                    for the creation of new instances, e.g. applications -->
+
+    <!-- The Resolutions -->
+    <bean id="res01" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="156543.03390625"></constructor-arg>
+    </bean>
+    <bean id="res02" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="78271.516953125"></constructor-arg>
+    </bean>
+    <bean id="res03" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="39135.7584765625"></constructor-arg>
+    </bean>
+    <bean id="res04" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="19567.87923828125"></constructor-arg>
+    </bean>
+    <bean id="res05" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="9783.939619140625"></constructor-arg>
+    </bean>
+    <bean id="res06" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="4891.9698095703125"></constructor-arg>
+    </bean>
+    <bean id="res07" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="2445.9849047851562"></constructor-arg>
+    </bean>
+    <bean id="res08" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="1222.9924523925781"></constructor-arg>
+    </bean>
+    <bean id="res09" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="611.4962261962891"></constructor-arg>
+    </bean>
+    <bean id="res10" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="305.74811309814453"></constructor-arg>
+    </bean>
+    <bean id="res11" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="152.87405654907226"></constructor-arg>
+    </bean>
+    <bean id="res12" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="76.43702827453613"></constructor-arg>
+    </bean>
+    <bean id="res13" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="38.218514137268066"></constructor-arg>
+    </bean>
+    <bean id="res14" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="19.109257068634033"></constructor-arg>
+    </bean>
+    <bean id="res15" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="9.554628534317017"></constructor-arg>
+    </bean>
+    <bean id="res16" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="4.777314267158508"></constructor-arg>
+    </bean>
+    <bean id="res17" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="2.388657133579254"></constructor-arg>
+    </bean>
+    <bean id="res18" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="1.194328566789627"></constructor-arg>
+    </bean>
+    <bean id="res19" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="0.5971642833948135"></constructor-arg>
+    </bean>
+
+    <!-- Default resolutions -->
+    <util:list id="defaultResolutions" value-type="java.lang.Double" scope="prototype">
+        <ref bean="res01" />
+        <ref bean="res02" />
+        <ref bean="res03" />
+        <ref bean="res04" />
+        <ref bean="res05" />
+        <ref bean="res06" />
+        <ref bean="res07" />
+        <ref bean="res08" />
+        <ref bean="res09" />
+        <ref bean="res10" />
+        <ref bean="res11" />
+        <ref bean="res12" />
+        <ref bean="res13" />
+        <ref bean="res14" />
+        <ref bean="res15" />
+        <ref bean="res16" />
+        <ref bean="res17" />
+        <ref bean="res18" />
+        <ref bean="res19" />
+    </util:list>
+
+    <!-- Default (max) extent -->
+    <bean id="defaultMaxExtent" class="de.terrestris.shogun2.model.layer.util.Extent" scope="prototype">
+        <property name="lowerLeft">
+            <bean class="java.awt.geom.Point2D$Double">
+                <constructor-arg index="0" value="-20026376.39" />
+                <constructor-arg index="1" value="-20048966.10" />
+            </bean>
+        </property>
+        <property name="upperRight">
+            <bean class="java.awt.geom.Point2D$Double">
+                <constructor-arg index="0" value="20026376.39" />
+                <constructor-arg index="1" value="20048966.10" />
+            </bean>
+        </property>
+    </bean>
+
+    <!-- Default map -->
+    <bean id="defaultMap" class="de.terrestris.shogun2.model.module.Map" scope="prototype">
+        <property name="xtype" value="momo-component-map" />
+        <property name="mapLayers">
+            <util:list>
+                <ref bean="osmWmsLayer" />
+            </util:list>
+        </property>
+        <property name="properties">
+             <util:map>
+                <entry key="x" value="0" />
+                <entry key="y" value="0" />
+                <entry key="width" value="100%" />
+                <entry key="height" value="100%" />
+            </util:map>
+        </property>
+    </bean>
+
+    <!-- Default MapContainer -->
+    <bean id="defaultMapContainer" class="de.terrestris.shogun2.model.module.CompositeModule" scope="prototype">
+        <property name="name" value="Map Container" />
+        <property name="xtype" value="container" />
+        <property name="properties">
+            <util:map>
+                <entry key="width" value="100%" />
+                <entry key="height" value="100%" />
+                <entry key="collapsible" value="false" />
+                <entry key="split" value="true" />
+                <entry key="region" value="center" />
+            </util:map>
+        </property>
+    </bean>
+
 </beans>

--- a/src/main/resources/META-INF/spring/dev/momo-context-initialize-beans.xml
+++ b/src/main/resources/META-INF/spring/dev/momo-context-initialize-beans.xml
@@ -455,66 +455,7 @@
         </property>
     </bean>
 
-    <!-- The Resolutions -->
-    <bean id="res01" class="java.lang.Double">
-        <constructor-arg value="156543.03390625"></constructor-arg>
-    </bean>
-    <bean id="res02" class="java.lang.Double">
-        <constructor-arg value="78271.516953125"></constructor-arg>
-    </bean>
-    <bean id="res03" class="java.lang.Double">
-        <constructor-arg value="39135.7584765625"></constructor-arg>
-    </bean>
-    <bean id="res04" class="java.lang.Double">
-        <constructor-arg value="19567.87923828125"></constructor-arg>
-    </bean>
-    <bean id="res05" class="java.lang.Double">
-        <constructor-arg value="9783.939619140625"></constructor-arg>
-    </bean>
-    <bean id="res06" class="java.lang.Double">
-        <constructor-arg value="4891.9698095703125"></constructor-arg>
-    </bean>
-    <bean id="res07" class="java.lang.Double">
-        <constructor-arg value="2445.9849047851562"></constructor-arg>
-    </bean>
-    <bean id="res08" class="java.lang.Double">
-        <constructor-arg value="1222.9924523925781"></constructor-arg>
-    </bean>
-    <bean id="res09" class="java.lang.Double">
-        <constructor-arg value="611.4962261962891"></constructor-arg>
-    </bean>
-    <bean id="res10" class="java.lang.Double">
-        <constructor-arg value="305.74811309814453"></constructor-arg>
-    </bean>
-    <bean id="res11" class="java.lang.Double">
-        <constructor-arg value="152.87405654907226"></constructor-arg>
-    </bean>
-    <bean id="res12" class="java.lang.Double">
-        <constructor-arg value="76.43702827453613"></constructor-arg>
-    </bean>
-    <bean id="res13" class="java.lang.Double">
-        <constructor-arg value="38.218514137268066"></constructor-arg>
-    </bean>
-    <bean id="res14" class="java.lang.Double">
-        <constructor-arg value="19.109257068634033"></constructor-arg>
-    </bean>
-    <bean id="res15" class="java.lang.Double">
-        <constructor-arg value="9.554628534317017"></constructor-arg>
-    </bean>
-    <bean id="res16" class="java.lang.Double">
-        <constructor-arg value="4.777314267158508"></constructor-arg>
-    </bean>
-    <bean id="res17" class="java.lang.Double">
-        <constructor-arg value="2.388657133579254"></constructor-arg>
-    </bean>
-    <bean id="res18" class="java.lang.Double">
-        <constructor-arg value="1.194328566789627"></constructor-arg>
-    </bean>
-    <bean id="res19" class="java.lang.Double">
-        <constructor-arg value="0.5971642833948135"></constructor-arg>
-    </bean>
-
-    <!-- Default extent -->
+    <!-- Extent -->
     <bean id="mapConfigExtent" class="de.terrestris.shogun2.model.layer.util.Extent">
         <property name="lowerLeft">
             <bean class="java.awt.geom.Point2D$Double">
@@ -541,29 +482,7 @@
         </property>
         <property name="minResolution" ref="res01" />
         <property name="maxResolution" ref="res19" />
-        <property name="resolutions">
-            <util:list>
-                <ref bean="res01" />
-                <ref bean="res02" />
-                <ref bean="res03" />
-                <ref bean="res04" />
-                <ref bean="res05" />
-                <ref bean="res06" />
-                <ref bean="res07" />
-                <ref bean="res08" />
-                <ref bean="res09" />
-                <ref bean="res10" />
-                <ref bean="res11" />
-                <ref bean="res12" />
-                <ref bean="res13" />
-                <ref bean="res14" />
-                <ref bean="res15" />
-                <ref bean="res16" />
-                <ref bean="res17" />
-                <ref bean="res18" />
-                <ref bean="res19" />
-            </util:list>
-        </property>
+        <property name="resolutions" ref="defaultResolutions" />
         <property name="extent">
             <ref bean="mapConfigExtent" />
         </property>
@@ -6721,4 +6640,146 @@
         <property name="expanded" value="true"/>
         <property name="root" value="true"/>
     </bean>
+
+
+    <!-- ******************************************************************* -->
+    <!-- ******************************************************************* -->
+    <!-- **************************  TEMPLATES  **************************** -->
+    <!-- ******************************************************************* -->
+    <!-- ******************************************************************* -->
+
+    <!-- The following beans are templates (usually with scope=prototype)
+                    for the creation of new instances, e.g. applications -->
+
+    <!-- The Resolutions -->
+    <bean id="res01" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="156543.03390625"></constructor-arg>
+    </bean>
+    <bean id="res02" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="78271.516953125"></constructor-arg>
+    </bean>
+    <bean id="res03" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="39135.7584765625"></constructor-arg>
+    </bean>
+    <bean id="res04" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="19567.87923828125"></constructor-arg>
+    </bean>
+    <bean id="res05" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="9783.939619140625"></constructor-arg>
+    </bean>
+    <bean id="res06" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="4891.9698095703125"></constructor-arg>
+    </bean>
+    <bean id="res07" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="2445.9849047851562"></constructor-arg>
+    </bean>
+    <bean id="res08" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="1222.9924523925781"></constructor-arg>
+    </bean>
+    <bean id="res09" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="611.4962261962891"></constructor-arg>
+    </bean>
+    <bean id="res10" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="305.74811309814453"></constructor-arg>
+    </bean>
+    <bean id="res11" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="152.87405654907226"></constructor-arg>
+    </bean>
+    <bean id="res12" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="76.43702827453613"></constructor-arg>
+    </bean>
+    <bean id="res13" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="38.218514137268066"></constructor-arg>
+    </bean>
+    <bean id="res14" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="19.109257068634033"></constructor-arg>
+    </bean>
+    <bean id="res15" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="9.554628534317017"></constructor-arg>
+    </bean>
+    <bean id="res16" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="4.777314267158508"></constructor-arg>
+    </bean>
+    <bean id="res17" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="2.388657133579254"></constructor-arg>
+    </bean>
+    <bean id="res18" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="1.194328566789627"></constructor-arg>
+    </bean>
+    <bean id="res19" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="0.5971642833948135"></constructor-arg>
+    </bean>
+
+    <!-- Default resolutions -->
+    <util:list id="defaultResolutions" value-type="java.lang.Double" scope="prototype">
+        <ref bean="res01" />
+        <ref bean="res02" />
+        <ref bean="res03" />
+        <ref bean="res04" />
+        <ref bean="res05" />
+        <ref bean="res06" />
+        <ref bean="res07" />
+        <ref bean="res08" />
+        <ref bean="res09" />
+        <ref bean="res10" />
+        <ref bean="res11" />
+        <ref bean="res12" />
+        <ref bean="res13" />
+        <ref bean="res14" />
+        <ref bean="res15" />
+        <ref bean="res16" />
+        <ref bean="res17" />
+        <ref bean="res18" />
+        <ref bean="res19" />
+    </util:list>
+
+    <!-- Default (max) extent -->
+    <bean id="defaultMaxExtent" class="de.terrestris.shogun2.model.layer.util.Extent" scope="prototype">
+        <property name="lowerLeft">
+            <bean class="java.awt.geom.Point2D$Double">
+                <constructor-arg index="0" value="-20026376.39" />
+                <constructor-arg index="1" value="-20048966.10" />
+            </bean>
+        </property>
+        <property name="upperRight">
+            <bean class="java.awt.geom.Point2D$Double">
+                <constructor-arg index="0" value="20026376.39" />
+                <constructor-arg index="1" value="20048966.10" />
+            </bean>
+        </property>
+    </bean>
+
+    <!-- Default map -->
+    <bean id="defaultMap" class="de.terrestris.shogun2.model.module.Map" scope="prototype">
+        <property name="xtype" value="momo-component-map" />
+        <property name="mapLayers">
+            <util:list>
+                <ref bean="osmWmsLayer" />
+            </util:list>
+        </property>
+        <property name="properties">
+             <util:map>
+                <entry key="x" value="0" />
+                <entry key="y" value="0" />
+                <entry key="width" value="100%" />
+                <entry key="height" value="100%" />
+            </util:map>
+        </property>
+    </bean>
+
+    <!-- Default MapContainer -->
+    <bean id="defaultMapContainer" class="de.terrestris.shogun2.model.module.CompositeModule" scope="prototype">
+        <property name="name" value="Map Container" />
+        <property name="xtype" value="container" />
+        <property name="properties">
+            <util:map>
+                <entry key="width" value="100%" />
+                <entry key="height" value="100%" />
+                <entry key="collapsible" value="false" />
+                <entry key="split" value="true" />
+                <entry key="region" value="center" />
+            </util:map>
+        </property>
+    </bean>
+
 </beans>

--- a/src/main/resources/META-INF/spring/prod/momo-context-initialize-beans.xml
+++ b/src/main/resources/META-INF/spring/prod/momo-context-initialize-beans.xml
@@ -274,6 +274,8 @@
         <ref bean="zoomToExtentModule" />
         <ref bean="stepBackModule" />
         <ref bean="stepForwardModule" />
+        <ref bean="showMeasureToolsModule" />
+        <ref bean="showRedliningToolsModule" />
 
         <ref bean="showMetaToolbarModule" />
         <ref bean="metaToolbarModule" />
@@ -453,66 +455,7 @@
         </property>
     </bean>
 
-    <!-- The Resolutions -->
-    <bean id="res01" class="java.lang.Double">
-        <constructor-arg value="156543.03390625"></constructor-arg>
-    </bean>
-    <bean id="res02" class="java.lang.Double">
-        <constructor-arg value="78271.516953125"></constructor-arg>
-    </bean>
-    <bean id="res03" class="java.lang.Double">
-        <constructor-arg value="39135.7584765625"></constructor-arg>
-    </bean>
-    <bean id="res04" class="java.lang.Double">
-        <constructor-arg value="19567.87923828125"></constructor-arg>
-    </bean>
-    <bean id="res05" class="java.lang.Double">
-        <constructor-arg value="9783.939619140625"></constructor-arg>
-    </bean>
-    <bean id="res06" class="java.lang.Double">
-        <constructor-arg value="4891.9698095703125"></constructor-arg>
-    </bean>
-    <bean id="res07" class="java.lang.Double">
-        <constructor-arg value="2445.9849047851562"></constructor-arg>
-    </bean>
-    <bean id="res08" class="java.lang.Double">
-        <constructor-arg value="1222.9924523925781"></constructor-arg>
-    </bean>
-    <bean id="res09" class="java.lang.Double">
-        <constructor-arg value="611.4962261962891"></constructor-arg>
-    </bean>
-    <bean id="res10" class="java.lang.Double">
-        <constructor-arg value="305.74811309814453"></constructor-arg>
-    </bean>
-    <bean id="res11" class="java.lang.Double">
-        <constructor-arg value="152.87405654907226"></constructor-arg>
-    </bean>
-    <bean id="res12" class="java.lang.Double">
-        <constructor-arg value="76.43702827453613"></constructor-arg>
-    </bean>
-    <bean id="res13" class="java.lang.Double">
-        <constructor-arg value="38.218514137268066"></constructor-arg>
-    </bean>
-    <bean id="res14" class="java.lang.Double">
-        <constructor-arg value="19.109257068634033"></constructor-arg>
-    </bean>
-    <bean id="res15" class="java.lang.Double">
-        <constructor-arg value="9.554628534317017"></constructor-arg>
-    </bean>
-    <bean id="res16" class="java.lang.Double">
-        <constructor-arg value="4.777314267158508"></constructor-arg>
-    </bean>
-    <bean id="res17" class="java.lang.Double">
-        <constructor-arg value="2.388657133579254"></constructor-arg>
-    </bean>
-    <bean id="res18" class="java.lang.Double">
-        <constructor-arg value="1.194328566789627"></constructor-arg>
-    </bean>
-    <bean id="res19" class="java.lang.Double">
-        <constructor-arg value="0.5971642833948135"></constructor-arg>
-    </bean>
-
-    <!-- Default extent -->
+    <!-- Extent -->
     <bean id="mapConfigExtent" class="de.terrestris.shogun2.model.layer.util.Extent">
         <property name="lowerLeft">
             <bean class="java.awt.geom.Point2D$Double">
@@ -539,29 +482,7 @@
         </property>
         <property name="minResolution" ref="res01" />
         <property name="maxResolution" ref="res19" />
-        <property name="resolutions">
-            <util:list>
-                <ref bean="res01" />
-                <ref bean="res02" />
-                <ref bean="res03" />
-                <ref bean="res04" />
-                <ref bean="res05" />
-                <ref bean="res06" />
-                <ref bean="res07" />
-                <ref bean="res08" />
-                <ref bean="res09" />
-                <ref bean="res10" />
-                <ref bean="res11" />
-                <ref bean="res12" />
-                <ref bean="res13" />
-                <ref bean="res14" />
-                <ref bean="res15" />
-                <ref bean="res16" />
-                <ref bean="res17" />
-                <ref bean="res18" />
-                <ref bean="res19" />
-            </util:list>
-        </property>
+        <property name="resolutions" ref="defaultResolutions" />
         <property name="extent">
             <ref bean="mapConfigExtent" />
         </property>
@@ -6363,6 +6284,28 @@
         </property>
     </bean>
 
+    <bean id="showMeasureToolsModule" class="de.terrestris.shogun2.model.module.Button">
+        <property name="name" value="Show measure tools button" />
+        <property name="xtype" value="momo-button-showmeasuretoolspanel" />
+        <property name="properties">
+             <util:map>
+                <entry key="scale" value="small" />
+                <entry key="ui" value="default" />
+             </util:map>
+        </property>
+    </bean>
+
+    <bean id="showRedliningToolsModule" class="de.terrestris.shogun2.model.module.Button">
+        <property name="name" value="Show redlining tools button" />
+        <property name="xtype" value="momo-button-showredliningtoolspanel" />
+        <property name="properties">
+             <util:map>
+                <entry key="scale" value="small" />
+                <entry key="ui" value="default" />
+             </util:map>
+        </property>
+    </bean>
+
     <bean id="showMetaToolbarModule" class="de.terrestris.shogun2.model.module.Button">
         <property name="name" value="Show meta toolbar button" />
         <property name="xtype" value="momo-button-showmetapanel" />
@@ -6399,6 +6342,8 @@
                 <ref bean="zoomToExtentModule" />
                 <ref bean="stepBackModule" />
                 <ref bean="stepForwardModule" />
+                <ref bean="showMeasureToolsModule" />
+                <ref bean="showRedliningToolsModule" />
             </util:list>
         </property>
     </bean>
@@ -6695,4 +6640,146 @@
         <property name="expanded" value="true"/>
         <property name="root" value="true"/>
     </bean>
+
+
+    <!-- ******************************************************************* -->
+    <!-- ******************************************************************* -->
+    <!-- **************************  TEMPLATES  **************************** -->
+    <!-- ******************************************************************* -->
+    <!-- ******************************************************************* -->
+
+    <!-- The following beans are templates (usually with scope=prototype)
+                    for the creation of new instances, e.g. applications -->
+
+    <!-- The Resolutions -->
+    <bean id="res01" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="156543.03390625"></constructor-arg>
+    </bean>
+    <bean id="res02" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="78271.516953125"></constructor-arg>
+    </bean>
+    <bean id="res03" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="39135.7584765625"></constructor-arg>
+    </bean>
+    <bean id="res04" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="19567.87923828125"></constructor-arg>
+    </bean>
+    <bean id="res05" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="9783.939619140625"></constructor-arg>
+    </bean>
+    <bean id="res06" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="4891.9698095703125"></constructor-arg>
+    </bean>
+    <bean id="res07" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="2445.9849047851562"></constructor-arg>
+    </bean>
+    <bean id="res08" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="1222.9924523925781"></constructor-arg>
+    </bean>
+    <bean id="res09" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="611.4962261962891"></constructor-arg>
+    </bean>
+    <bean id="res10" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="305.74811309814453"></constructor-arg>
+    </bean>
+    <bean id="res11" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="152.87405654907226"></constructor-arg>
+    </bean>
+    <bean id="res12" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="76.43702827453613"></constructor-arg>
+    </bean>
+    <bean id="res13" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="38.218514137268066"></constructor-arg>
+    </bean>
+    <bean id="res14" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="19.109257068634033"></constructor-arg>
+    </bean>
+    <bean id="res15" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="9.554628534317017"></constructor-arg>
+    </bean>
+    <bean id="res16" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="4.777314267158508"></constructor-arg>
+    </bean>
+    <bean id="res17" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="2.388657133579254"></constructor-arg>
+    </bean>
+    <bean id="res18" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="1.194328566789627"></constructor-arg>
+    </bean>
+    <bean id="res19" class="java.lang.Double" scope="prototype">
+        <constructor-arg value="0.5971642833948135"></constructor-arg>
+    </bean>
+
+    <!-- Default resolutions -->
+    <util:list id="defaultResolutions" value-type="java.lang.Double" scope="prototype">
+        <ref bean="res01" />
+        <ref bean="res02" />
+        <ref bean="res03" />
+        <ref bean="res04" />
+        <ref bean="res05" />
+        <ref bean="res06" />
+        <ref bean="res07" />
+        <ref bean="res08" />
+        <ref bean="res09" />
+        <ref bean="res10" />
+        <ref bean="res11" />
+        <ref bean="res12" />
+        <ref bean="res13" />
+        <ref bean="res14" />
+        <ref bean="res15" />
+        <ref bean="res16" />
+        <ref bean="res17" />
+        <ref bean="res18" />
+        <ref bean="res19" />
+    </util:list>
+
+    <!-- Default (max) extent -->
+    <bean id="defaultMaxExtent" class="de.terrestris.shogun2.model.layer.util.Extent" scope="prototype">
+        <property name="lowerLeft">
+            <bean class="java.awt.geom.Point2D$Double">
+                <constructor-arg index="0" value="-20026376.39" />
+                <constructor-arg index="1" value="-20048966.10" />
+            </bean>
+        </property>
+        <property name="upperRight">
+            <bean class="java.awt.geom.Point2D$Double">
+                <constructor-arg index="0" value="20026376.39" />
+                <constructor-arg index="1" value="20048966.10" />
+            </bean>
+        </property>
+    </bean>
+
+    <!-- Default map -->
+    <bean id="defaultMap" class="de.terrestris.shogun2.model.module.Map" scope="prototype">
+        <property name="xtype" value="momo-component-map" />
+        <property name="mapLayers">
+            <util:list>
+                <ref bean="osmWmsLayer" />
+            </util:list>
+        </property>
+        <property name="properties">
+             <util:map>
+                <entry key="x" value="0" />
+                <entry key="y" value="0" />
+                <entry key="width" value="100%" />
+                <entry key="height" value="100%" />
+            </util:map>
+        </property>
+    </bean>
+
+    <!-- Default MapContainer -->
+    <bean id="defaultMapContainer" class="de.terrestris.shogun2.model.module.CompositeModule" scope="prototype">
+        <property name="name" value="Map Container" />
+        <property name="xtype" value="container" />
+        <property name="properties">
+            <util:map>
+                <entry key="width" value="100%" />
+                <entry key="height" value="100%" />
+                <entry key="collapsible" value="false" />
+                <entry key="split" value="true" />
+                <entry key="region" value="center" />
+            </util:map>
+        </property>
+    </bean>
+
 </beans>


### PR DESCRIPTION
This PR contains a first backend implementation for the creation of new webapps and introduces or changes the following:
- Use an `ApplicationData` data transfer object (for easy deserialization of application data (JSON) that is sent from the client to the backend)
- Restructuring of the init beans xml (with new template/prototype beans)
- Web interface for the app creation
- Service implementation

Currently, the implementation only supports the following things to be sent by the client:
- General information (name, description, language etc)
- Startview

What's still missing is the ability to configure tools and layers (!) for a new webapp
