### PR TITLE
HSI tool module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "src/main/webapp/lib/ol3"]
 	path = src/main/webapp/lib/ol3
 	url = https://github.com/openlayers/ol3.git # by tag v3.17.1 (eb92c26)
+[submodule "src/main/webapp/lib/proj4"]
+	path = src/main/webapp/lib/proj4
+	url = http://gitlab.intranet.terrestris.de/libraries/proj4js-2.3.6.git

--- a/src/main/java/de/terrestris/momo/interceptor/MomoWmsResponseInterceptor.java
+++ b/src/main/java/de/terrestris/momo/interceptor/MomoWmsResponseInterceptor.java
@@ -77,31 +77,32 @@ public class MomoWmsResponseInterceptor implements WmsResponseInterceptorInterfa
 	@Override
 	public Response interceptGetCapabilities(MutableHttpServletRequest mutableRequest, Response response) {
 		// TODO Auto-generated method stub
-		return null;
+		return response;
 	}
 
 	@Override
 	public Response interceptGetFeatureInfo(MutableHttpServletRequest mutableRequest, Response response) {
-		// TODO Auto-generated method stub
-		return null;
+		// TODO Implement logic to consider the masking layer by GFI response
+		// (e.g. all objects outside of allowed bbox shouldn't be queryable)
+		return response;
 	}
 
 	@Override
 	public Response interceptDescribeLayer(MutableHttpServletRequest mutableRequest, Response response) {
 		// TODO Auto-generated method stub
-		return null;
+		return response;
 	}
 
 	@Override
 	public Response interceptGetLegendGraphic(MutableHttpServletRequest mutableRequest, Response response) {
 		// TODO Auto-generated method stub
-		return null;
+		return response;
 	}
 
 	@Override
 	public Response interceptGetStyles(MutableHttpServletRequest mutableRequest, Response response) {
 		// TODO Auto-generated method stub
-		return null;
+		return response;
 	}
 
 	/**

--- a/src/main/java/de/terrestris/momo/model/MomoLayer.java
+++ b/src/main/java/de/terrestris/momo/model/MomoLayer.java
@@ -34,6 +34,11 @@ public class MomoLayer extends Layer {
 	/**
 	 *
 	 */
+	private Boolean hoverable;
+
+	/**
+	 *
+	 */
 	public MomoLayer() {
 	}
 
@@ -52,6 +57,20 @@ public class MomoLayer extends Layer {
 	}
 
 	/**
+	 * @return the hoverable
+	 */
+	public Boolean getHoverable() {
+		return hoverable;
+	}
+
+	/**
+	 * @param hoverable the hoverable to set
+	 */
+	public void setHoverable(Boolean hoverable) {
+		this.hoverable = hoverable;
+	}
+
+	/**
 	 * @see java.lang.Object#hashCode()
 	 *
 	 *      According to
@@ -65,6 +84,7 @@ public class MomoLayer extends Layer {
 		return new HashCodeBuilder(29, 11).
 				appendSuper(super.hashCode()).
 				append(getSpatiallyRestricted()).
+				append(getHoverable()).
 				toHashCode();
 	}
 

--- a/src/main/java/de/terrestris/momo/model/MomoLayer.java
+++ b/src/main/java/de/terrestris/momo/model/MomoLayer.java
@@ -105,6 +105,7 @@ public class MomoLayer extends Layer {
 		return new EqualsBuilder().
 				appendSuper(super.equals(other)).
 				append(getSpatiallyRestricted(), other.getSpatiallyRestricted()).
+				append(getHoverable(), other.getHoverable()).
 				isEquals();
 	}
 

--- a/src/main/resources/META-INF/spring/ci/momo-context-initialize-beans.xml
+++ b/src/main/resources/META-INF/spring/ci/momo-context-initialize-beans.xml
@@ -7,7 +7,7 @@
                            http://www.springframework.org/schema/util
                            http://www.springframework.org/schema/util/spring-util.xsd">
 
-    <!--t
+    <!--
       The list of objects that shall be persisted.
 
       The order of the objects is important here (as one object may require
@@ -274,6 +274,7 @@
         <ref bean="zoomToExtentModule" />
         <ref bean="stepBackModule" />
         <ref bean="stepForwardModule" />
+        <ref bean="hsiToolsModule" />
         <ref bean="showMeasureToolsModule" />
         <ref bean="showRedliningToolsModule" />
 
@@ -3304,6 +3305,7 @@
         <property name="source" ref="mongoliaStateCentersDataSource" />
         <property name="appearance" ref="mongoliaStateCentersAppearance" />
         <property name="spatiallyRestricted" value="true" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3317,6 +3319,7 @@
         <property name="source" ref="osmTopoDataSource" />
         <property name="appearance" ref="osmTopoAppearance" />
         <property name="spatiallyRestricted" value="true" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3330,6 +3333,7 @@
         <property name="source" ref="01_kharaa_river_basin_32648DataSource" />
         <property name="appearance" ref="01_kharaa_river_basin_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3343,6 +3347,7 @@
         <property name="source" ref="01_kharaa_subbasins_32648DataSource" />
         <property name="appearance" ref="01_kharaa_subbasins_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3356,6 +3361,7 @@
         <property name="source" ref="02_surface_water_bodies_32648DataSource" />
         <property name="appearance" ref="02_surface_water_bodies_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3369,6 +3375,7 @@
         <property name="source" ref="02_surface_water_bodies_corr_32648DataSource" />
         <property name="appearance" ref="02_surface_water_bodies_corr_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3382,6 +3389,7 @@
         <property name="source" ref="03_groundwater_bodies_32648DataSource" />
         <property name="appearance" ref="03_groundwater_bodies_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3395,6 +3403,7 @@
         <property name="source" ref="03_groundwater_monitoring_sites_32648DataSource" />
         <property name="appearance" ref="03_groundwater_monitoring_sites_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3408,6 +3417,7 @@
         <property name="source" ref="07_mining_operations_32648DataSource" />
         <property name="appearance" ref="07_mining_operations_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3421,6 +3431,7 @@
         <property name="source" ref="07_potentially_contaminated_areas_32648DataSource" />
         <property name="appearance" ref="07_potentially_contaminated_areas_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3434,6 +3445,7 @@
         <property name="source" ref="07_risk_assessment_groundwater_bodies_32648DataSource" />
         <property name="appearance" ref="07_risk_assessment_groundwater_bodies_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3447,6 +3459,7 @@
         <property name="source" ref="07_risk_assessment_surface_water_bodies_32648DataSource" />
         <property name="appearance" ref="07_risk_assessment_surface_water_bodies_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3460,6 +3473,7 @@
         <property name="source" ref="2085_prec_sum_mngDataSource" />
         <property name="appearance" ref="2085_prec_sum_mngAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3473,6 +3487,7 @@
         <property name="source" ref="aet_1971-00DataSource" />
         <property name="appearance" ref="aet_1971-00Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3486,6 +3501,7 @@
         <property name="source" ref="aimag_boundaryDataSource" />
         <property name="appearance" ref="aimag_boundaryAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3499,6 +3515,7 @@
         <property name="source" ref="aimag_centerDataSource" />
         <property name="appearance" ref="aimag_centerAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3512,6 +3529,7 @@
         <property name="source" ref="aimagboundaryDataSource" />
         <property name="appearance" ref="aimagboundaryAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3525,6 +3543,7 @@
         <property name="source" ref="avail_1971-00DataSource" />
         <property name="appearance" ref="avail_1971-00Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3538,6 +3557,7 @@
         <property name="source" ref="avail_2011-40_a2_cncm3DataSource" />
         <property name="appearance" ref="avail_2011-40_a2_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3551,6 +3571,7 @@
         <property name="source" ref="avail_2011-40_a2_echam5DataSource" />
         <property name="appearance" ref="avail_2011-40_a2_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3564,6 +3585,7 @@
         <property name="source" ref="avail_2011-40_a2_ipslDataSource" />
         <property name="appearance" ref="avail_2011-40_a2_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3577,6 +3599,7 @@
         <property name="source" ref="avail_2011-40_b1_cncm3DataSource" />
         <property name="appearance" ref="avail_2011-40_b1_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3590,6 +3613,7 @@
         <property name="source" ref="avail_2011-40_b1_echam5DataSource" />
         <property name="appearance" ref="avail_2011-40_b1_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3603,6 +3627,7 @@
         <property name="source" ref="avail_2011-40_b1_ipslDataSource" />
         <property name="appearance" ref="avail_2011-40_b1_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3616,6 +3641,7 @@
         <property name="source" ref="avail_2041-70_a2_cncm3DataSource" />
         <property name="appearance" ref="avail_2041-70_a2_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3629,6 +3655,7 @@
         <property name="source" ref="avail_2041-70_a2_echam5DataSource" />
         <property name="appearance" ref="avail_2041-70_a2_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3642,6 +3669,7 @@
         <property name="source" ref="avail_2041-70_a2_ipslDataSource" />
         <property name="appearance" ref="avail_2041-70_a2_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3655,6 +3683,7 @@
         <property name="source" ref="avail_2041-70_b1_cncm3DataSource" />
         <property name="appearance" ref="avail_2041-70_b1_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3668,6 +3697,7 @@
         <property name="source" ref="avail_2041-70_b1_echam5DataSource" />
         <property name="appearance" ref="avail_2041-70_b1_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3681,6 +3711,7 @@
         <property name="source" ref="avail_2041-70_b1_ipslDataSource" />
         <property name="appearance" ref="avail_2041-70_b1_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3694,6 +3725,7 @@
         <property name="source" ref="avail_2071-00_a2_cncm3DataSource" />
         <property name="appearance" ref="avail_2071-00_a2_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3707,6 +3739,7 @@
         <property name="source" ref="avail_2071-00_a2_echam5DataSource" />
         <property name="appearance" ref="avail_2071-00_a2_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3720,6 +3753,7 @@
         <property name="source" ref="avail_2071-00_a2_ipslDataSource" />
         <property name="appearance" ref="avail_2071-00_a2_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3733,6 +3767,7 @@
         <property name="source" ref="avail_2071-00_b1_cncm3DataSource" />
         <property name="appearance" ref="avail_2071-00_b1_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3746,6 +3781,7 @@
         <property name="source" ref="avail_2071-00_b1_echam5DataSource" />
         <property name="appearance" ref="avail_2071-00_b1_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3759,6 +3795,7 @@
         <property name="source" ref="avail_2071-00_b1_ipslDataSource" />
         <property name="appearance" ref="avail_2071-00_b1_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3772,6 +3809,7 @@
         <property name="source" ref="big_riversDataSource" />
         <property name="appearance" ref="big_riversAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3785,6 +3823,7 @@
         <property name="source" ref="blue_marbleDataSource" />
         <property name="appearance" ref="blue_marbleAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3798,6 +3837,7 @@
         <property name="source" ref="buildingsDataSource" />
         <property name="appearance" ref="buildingsAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3811,6 +3851,7 @@
         <property name="source" ref="country_bordersDataSource" />
         <property name="appearance" ref="country_bordersAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3824,6 +3865,7 @@
         <property name="source" ref="cropland_1989_kharaaDataSource" />
         <property name="appearance" ref="cropland_1989_kharaaAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3837,6 +3879,7 @@
         <property name="source" ref="cropland_2006_kharaaDataSource" />
         <property name="appearance" ref="cropland_2006_kharaaAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3850,6 +3893,7 @@
         <property name="source" ref="DEM_30mDataSource" />
         <property name="appearance" ref="DEM_30mAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3863,6 +3907,7 @@
         <property name="source" ref="DEM_Mongolia_900mDataSource" />
         <property name="appearance" ref="DEM_Mongolia_900mAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3876,6 +3921,7 @@
         <property name="source" ref="digiriver_subbasinsDataSource" />
         <property name="appearance" ref="digiriver_subbasinsAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3889,6 +3935,7 @@
         <property name="source" ref="dyn_17_1369841595246DataSource" />
         <property name="appearance" ref="dyn_17_1369841595246Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3902,6 +3949,7 @@
         <property name="source" ref="ecological_status_kharaaDataSource" />
         <property name="appearance" ref="ecological_status_kharaaAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3915,6 +3963,7 @@
         <property name="source" ref="ecological_status_kharaa_uploadtestDataSource" />
         <property name="appearance" ref="ecological_status_kharaa_uploadtestAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3928,6 +3977,7 @@
         <property name="source" ref="einwohnerdichteDataSource" />
         <property name="appearance" ref="einwohnerdichteAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3941,6 +3991,7 @@
         <property name="source" ref="einwohnerdichte_darhanDataSource" />
         <property name="appearance" ref="einwohnerdichte_darhanAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3954,6 +4005,7 @@
         <property name="source" ref="gebaeudeDataSource" />
         <property name="appearance" ref="gebaeudeAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3967,6 +4019,7 @@
         <property name="source" ref="gebaeude_darkhan_32648_clipDataSource" />
         <property name="appearance" ref="gebaeude_darkhan_32648_clipAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3980,6 +4033,7 @@
         <property name="source" ref="gebaeude_darkhan_32648_clip_tryDataSource" />
         <property name="appearance" ref="gebaeude_darkhan_32648_clip_tryAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3993,6 +4047,7 @@
         <property name="source" ref="gebaeude1_darhanDataSource" />
         <property name="appearance" ref="gebaeude1_darhanAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4006,6 +4061,7 @@
         <property name="source" ref="golDataSource" />
         <property name="appearance" ref="golAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4019,6 +4075,7 @@
         <property name="source" ref="kharaa_basinDataSource" />
         <property name="appearance" ref="kharaa_basinAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4032,6 +4089,7 @@
         <property name="source" ref="kharaa_darhanDataSource" />
         <property name="appearance" ref="kharaa_darhanAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4045,6 +4103,7 @@
         <property name="source" ref="kharaa_subbasinsDataSource" />
         <property name="appearance" ref="kharaa_subbasinsAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4058,6 +4117,7 @@
         <property name="source" ref="lakes_largeDataSource" />
         <property name="appearance" ref="lakes_largeAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4071,6 +4131,7 @@
         <property name="source" ref="landuseDataSource" />
         <property name="appearance" ref="landuseAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4084,6 +4145,7 @@
         <property name="source" ref="mng_roadsDataSource" />
         <property name="appearance" ref="mng_roadsAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4097,6 +4159,7 @@
         <property name="source" ref="naturalDataSource" />
         <property name="appearance" ref="naturalAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4110,6 +4173,7 @@
         <property name="source" ref="nuuruudDataSource" />
         <property name="appearance" ref="nuuruudAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4123,6 +4187,7 @@
         <property name="source" ref="ortho_drone_oczipkaDataSource" />
         <property name="appearance" ref="ortho_drone_oczipkaAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4136,6 +4201,7 @@
         <property name="source" ref="permafrostDataSource" />
         <property name="appearance" ref="permafrostAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4149,6 +4215,7 @@
         <property name="source" ref="phenomenonzonemetaDataSource" />
         <property name="appearance" ref="phenomenonzonemetaAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4162,6 +4229,7 @@
         <property name="source" ref="placesDataSource" />
         <property name="appearance" ref="placesAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4175,6 +4243,7 @@
         <property name="source" ref="pointsDataSource" />
         <property name="appearance" ref="pointsAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4188,6 +4257,7 @@
         <property name="source" ref="populationdensity_darhanDataSource" />
         <property name="appearance" ref="populationdensity_darhanAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4201,6 +4271,7 @@
         <property name="source" ref="precip_1971-00DataSource" />
         <property name="appearance" ref="precip_1971-00Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4214,6 +4285,7 @@
         <property name="source" ref="precip_2011-40_a2_cncm3DataSource" />
         <property name="appearance" ref="precip_2011-40_a2_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4227,6 +4299,7 @@
         <property name="source" ref="precip_2011-40_a2_echam5DataSource" />
         <property name="appearance" ref="precip_2011-40_a2_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4240,6 +4313,7 @@
         <property name="source" ref="precip_2011-40_a2_ipslDataSource" />
         <property name="appearance" ref="precip_2011-40_a2_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4253,6 +4327,7 @@
         <property name="source" ref="precip_2011-40_b1_cncm3DataSource" />
         <property name="appearance" ref="precip_2011-40_b1_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4266,6 +4341,7 @@
         <property name="source" ref="precip_2011-40_b1_echam5DataSource" />
         <property name="appearance" ref="precip_2011-40_b1_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4279,6 +4355,7 @@
         <property name="source" ref="precip_2011-40_b1_ipslDataSource" />
         <property name="appearance" ref="precip_2011-40_b1_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4292,6 +4369,7 @@
         <property name="source" ref="precip_2041-70_a2_cncm3DataSource" />
         <property name="appearance" ref="precip_2041-70_a2_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4305,6 +4383,7 @@
         <property name="source" ref="precip_2041-70_a2_echam5DataSource" />
         <property name="appearance" ref="precip_2041-70_a2_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4318,6 +4397,7 @@
         <property name="source" ref="precip_2041-70_a2_ipslDataSource" />
         <property name="appearance" ref="precip_2041-70_a2_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4331,6 +4411,7 @@
         <property name="source" ref="precip_2041-70_b1_cncm3DataSource" />
         <property name="appearance" ref="precip_2041-70_b1_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4344,6 +4425,7 @@
         <property name="source" ref="precip_2041-70_b1_echam5DataSource" />
         <property name="appearance" ref="precip_2041-70_b1_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4357,6 +4439,7 @@
         <property name="source" ref="precip_2041-70_b1_ipslDataSource" />
         <property name="appearance" ref="precip_2041-70_b1_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4370,6 +4453,7 @@
         <property name="source" ref="precip_2071-00_a2_cncm3DataSource" />
         <property name="appearance" ref="precip_2071-00_a2_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4383,6 +4467,7 @@
         <property name="source" ref="precip_2071-00_a2_echam5DataSource" />
         <property name="appearance" ref="precip_2071-00_a2_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4396,6 +4481,7 @@
         <property name="source" ref="precip_2071-00_a2_ipslDataSource" />
         <property name="appearance" ref="precip_2071-00_a2_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4409,6 +4495,7 @@
         <property name="source" ref="precip_2071-00_b1_cncm3DataSource" />
         <property name="appearance" ref="precip_2071-00_b1_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4422,6 +4509,7 @@
         <property name="source" ref="precip_2071-00_b1_echam5DataSource" />
         <property name="appearance" ref="precip_2071-00_b1_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4435,6 +4523,7 @@
         <property name="source" ref="precip_2071-00_b1_ipslDataSource" />
         <property name="appearance" ref="precip_2071-00_b1_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4448,6 +4537,7 @@
         <property name="source" ref="protected_areasDataSource" />
         <property name="appearance" ref="protected_areasAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4461,6 +4551,7 @@
         <property name="source" ref="rail_roadDataSource" />
         <property name="appearance" ref="rail_roadAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4474,6 +4565,7 @@
         <property name="source" ref="railwaysDataSource" />
         <property name="appearance" ref="railwaysAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4487,6 +4579,7 @@
         <property name="source" ref="roadsDataSource" />
         <property name="appearance" ref="roadsAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4500,6 +4593,7 @@
         <property name="source" ref="snow_cover_fraction_1971-00DataSource" />
         <property name="appearance" ref="snow_cover_fraction_1971-00Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4513,6 +4607,7 @@
         <property name="source" ref="soum_center342DataSource" />
         <property name="appearance" ref="soum_center342Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4526,6 +4621,7 @@
         <property name="source" ref="state_boundaryDataSource" />
         <property name="appearance" ref="state_boundaryAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4539,6 +4635,7 @@
         <property name="source" ref="temp_1971-00DataSource" />
         <property name="appearance" ref="temp_1971-00Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4552,6 +4649,7 @@
         <property name="source" ref="temp_2011-40_a2_cncm3DataSource" />
         <property name="appearance" ref="temp_2011-40_a2_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4565,6 +4663,7 @@
         <property name="source" ref="temp_2011-40_a2_echam5DataSource" />
         <property name="appearance" ref="temp_2011-40_a2_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4578,6 +4677,7 @@
         <property name="source" ref="temp_2011-40_a2_ipslDataSource" />
         <property name="appearance" ref="temp_2011-40_a2_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4591,6 +4691,7 @@
         <property name="source" ref="temp_2011-40_b1_cncm3DataSource" />
         <property name="appearance" ref="temp_2011-40_b1_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4604,6 +4705,7 @@
         <property name="source" ref="temp_2011-40_b1_echam5DataSource" />
         <property name="appearance" ref="temp_2011-40_b1_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4617,6 +4719,7 @@
         <property name="source" ref="temp_2011-40_b1_ipslDataSource" />
         <property name="appearance" ref="temp_2011-40_b1_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4630,6 +4733,7 @@
         <property name="source" ref="temp_2041-70_a2_cncm3DataSource" />
         <property name="appearance" ref="temp_2041-70_a2_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4643,6 +4747,7 @@
         <property name="source" ref="temp_2041-70_a2_echam5DataSource" />
         <property name="appearance" ref="temp_2041-70_a2_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4656,6 +4761,7 @@
         <property name="source" ref="temp_2041-70_a2_ipslDataSource" />
         <property name="appearance" ref="temp_2041-70_a2_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4669,6 +4775,7 @@
         <property name="source" ref="temp_2041-70_b1_cncm3DataSource" />
         <property name="appearance" ref="temp_2041-70_b1_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4682,6 +4789,7 @@
         <property name="source" ref="temp_2041-70_b1_echam5DataSource" />
         <property name="appearance" ref="temp_2041-70_b1_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4695,6 +4803,7 @@
         <property name="source" ref="temp_2041-70_b1_ipslDataSource" />
         <property name="appearance" ref="temp_2041-70_b1_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4708,6 +4817,7 @@
         <property name="source" ref="temp_2071-00_a2_cncm3DataSource" />
         <property name="appearance" ref="temp_2071-00_a2_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4721,6 +4831,7 @@
         <property name="source" ref="temp_2071-00_a2_echam5DataSource" />
         <property name="appearance" ref="temp_2071-00_a2_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4734,6 +4845,7 @@
         <property name="source" ref="temp_2071-00_a2_ipslDataSource" />
         <property name="appearance" ref="temp_2071-00_a2_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4747,6 +4859,7 @@
         <property name="source" ref="temp_2071-00_b1_cncm3DataSource" />
         <property name="appearance" ref="temp_2071-00_b1_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4760,6 +4873,7 @@
         <property name="source" ref="temp_2071-00_b1_echam5DataSource" />
         <property name="appearance" ref="temp_2071-00_b1_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4773,6 +4887,7 @@
         <property name="source" ref="temp_2071-00_b1_ipslDataSource" />
         <property name="appearance" ref="temp_2071-00_b1_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4786,6 +4901,7 @@
         <property name="source" ref="TM5_2010DataSource" />
         <property name="appearance" ref="TM5_2010Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4799,6 +4915,7 @@
         <property name="source" ref="wasserkioske_bag7_32648DataSource" />
         <property name="appearance" ref="wasserkioske_bag7_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4812,6 +4929,7 @@
         <property name="source" ref="wastewater_darhanDataSource" />
         <property name="appearance" ref="wastewater_darhanAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4825,6 +4943,7 @@
         <property name="source" ref="waterwaysDataSource" />
         <property name="appearance" ref="waterwaysAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4838,6 +4957,7 @@
         <property name="source" ref="wg3_webgis_cruDataSource" />
         <property name="appearance" ref="wg3_webgis_cruAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4851,6 +4971,7 @@
         <property name="source" ref="DYN_109_1369735105591DataSource" />
         <property name="appearance" ref="DYN_109_1369735105591Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4864,6 +4985,7 @@
         <property name="source" ref="DYN_109_1369742468725DataSource" />
         <property name="appearance" ref="DYN_109_1369742468725Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4877,6 +4999,7 @@
         <property name="source" ref="DYN_109_1369841716922DataSource" />
         <property name="appearance" ref="DYN_109_1369841716922Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4890,6 +5013,7 @@
         <property name="source" ref="DYN_13_1365601378477DataSource" />
         <property name="appearance" ref="DYN_13_1365601378477Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4903,6 +5027,7 @@
         <property name="source" ref="DYN_13_1365601542355DataSource" />
         <property name="appearance" ref="DYN_13_1365601542355Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4916,6 +5041,7 @@
         <property name="source" ref="DYN_14_1365602120228DataSource" />
         <property name="appearance" ref="DYN_14_1365602120228Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4929,6 +5055,7 @@
         <property name="source" ref="DYN_14_1365605442839DataSource" />
         <property name="appearance" ref="DYN_14_1365605442839Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4942,6 +5069,7 @@
         <property name="source" ref="DYN_14_1365605456216DataSource" />
         <property name="appearance" ref="DYN_14_1365605456216Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4955,6 +5083,7 @@
         <property name="source" ref="DYN_14_1365605476506DataSource" />
         <property name="appearance" ref="DYN_14_1365605476506Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4968,6 +5097,7 @@
         <property name="source" ref="DYN_14_1365605781970DataSource" />
         <property name="appearance" ref="DYN_14_1365605781970Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4981,6 +5111,7 @@
         <property name="source" ref="DYN_14_1365605882959DataSource" />
         <property name="appearance" ref="DYN_14_1365605882959Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4994,6 +5125,7 @@
         <property name="source" ref="DYN_14_1365605890897DataSource" />
         <property name="appearance" ref="DYN_14_1365605890897Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5007,6 +5139,7 @@
         <property name="source" ref="DYN_14_1365605955459DataSource" />
         <property name="appearance" ref="DYN_14_1365605955459Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5020,6 +5153,7 @@
         <property name="source" ref="DYN_14_1365605978459DataSource" />
         <property name="appearance" ref="DYN_14_1365605978459Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5033,6 +5167,7 @@
         <property name="source" ref="DYN_14_1365605987568DataSource" />
         <property name="appearance" ref="DYN_14_1365605987568Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5046,6 +5181,7 @@
         <property name="source" ref="DYN_14_1365605992016DataSource" />
         <property name="appearance" ref="DYN_14_1365605992016Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5059,6 +5195,7 @@
         <property name="source" ref="DYN_14_1365605995942DataSource" />
         <property name="appearance" ref="DYN_14_1365605995942Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5072,6 +5209,7 @@
         <property name="source" ref="DYN_14_1365608956030DataSource" />
         <property name="appearance" ref="DYN_14_1365608956030Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5085,6 +5223,7 @@
         <property name="source" ref="DYN_14_1365694916518DataSource" />
         <property name="appearance" ref="DYN_14_1365694916518Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5098,6 +5237,7 @@
         <property name="source" ref="DYN_14_1365759012080DataSource" />
         <property name="appearance" ref="DYN_14_1365759012080Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5111,6 +5251,7 @@
         <property name="source" ref="DYN_14_1365759879641DataSource" />
         <property name="appearance" ref="DYN_14_1365759879641Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5124,6 +5265,7 @@
         <property name="source" ref="DYN_14_1365760699624DataSource" />
         <property name="appearance" ref="DYN_14_1365760699624Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5137,6 +5279,7 @@
         <property name="source" ref="DYN_14_1365761490659DataSource" />
         <property name="appearance" ref="DYN_14_1365761490659Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5150,6 +5293,7 @@
         <property name="source" ref="DYN_14_1365761504280DataSource" />
         <property name="appearance" ref="DYN_14_1365761504280Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5163,6 +5307,7 @@
         <property name="source" ref="DYN_14_1366635679454DataSource" />
         <property name="appearance" ref="DYN_14_1366635679454Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5176,6 +5321,7 @@
         <property name="source" ref="DYN_14_1366635904632DataSource" />
         <property name="appearance" ref="DYN_14_1366635904632Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5189,6 +5335,7 @@
         <property name="source" ref="DYN_14_1366704342968DataSource" />
         <property name="appearance" ref="DYN_14_1366704342968Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5202,6 +5349,7 @@
         <property name="source" ref="DYN_14_1367228008564DataSource" />
         <property name="appearance" ref="DYN_14_1367228008564Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5215,6 +5363,7 @@
         <property name="source" ref="DYN_14_1367848456001DataSource" />
         <property name="appearance" ref="DYN_14_1367848456001Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5228,6 +5377,7 @@
         <property name="source" ref="DYN_14_1367938733533DataSource" />
         <property name="appearance" ref="DYN_14_1367938733533Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5241,6 +5391,7 @@
         <property name="source" ref="DYN_14_1368001502620DataSource" />
         <property name="appearance" ref="DYN_14_1368001502620Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5254,6 +5405,7 @@
         <property name="source" ref="DYN_14_1368001531956DataSource" />
         <property name="appearance" ref="DYN_14_1368001531956Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5267,6 +5419,7 @@
         <property name="source" ref="DYN_14_1368431465466DataSource" />
         <property name="appearance" ref="DYN_14_1368431465466Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5280,6 +5433,7 @@
         <property name="source" ref="DYN_14_1369216335515DataSource" />
         <property name="appearance" ref="DYN_14_1369216335515Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5293,6 +5447,7 @@
         <property name="source" ref="DYN_14_1369390350022DataSource" />
         <property name="appearance" ref="DYN_14_1369390350022Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5306,6 +5461,7 @@
         <property name="source" ref="DYN_14_1369657232648DataSource" />
         <property name="appearance" ref="DYN_14_1369657232648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5319,6 +5475,7 @@
         <property name="source" ref="DYN_15_1365608726707DataSource" />
         <property name="appearance" ref="DYN_15_1365608726707Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5332,6 +5489,7 @@
         <property name="source" ref="DYN_15_1365608732880DataSource" />
         <property name="appearance" ref="DYN_15_1365608732880Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5345,6 +5503,7 @@
         <property name="source" ref="DYN_15_1365608753118DataSource" />
         <property name="appearance" ref="DYN_15_1365608753118Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5358,6 +5517,7 @@
         <property name="source" ref="DYN_15_1365608802067DataSource" />
         <property name="appearance" ref="DYN_15_1365608802067Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5371,6 +5531,7 @@
         <property name="source" ref="DYN_15_1365608806430DataSource" />
         <property name="appearance" ref="DYN_15_1365608806430Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5384,6 +5545,7 @@
         <property name="source" ref="DYN_15_1365610632020DataSource" />
         <property name="appearance" ref="DYN_15_1365610632020Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5397,6 +5559,7 @@
         <property name="source" ref="DYN_17_1369658293805DataSource" />
         <property name="appearance" ref="DYN_17_1369658293805Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5410,6 +5573,7 @@
         <property name="source" ref="DYN_17_1369661200358DataSource" />
         <property name="appearance" ref="DYN_17_1369661200358Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5423,6 +5587,7 @@
         <property name="source" ref="DYN_17_1369663868865DataSource" />
         <property name="appearance" ref="DYN_17_1369663868865Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5436,6 +5601,7 @@
         <property name="source" ref="DYN_17_1369664218638DataSource" />
         <property name="appearance" ref="DYN_17_1369664218638Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5449,6 +5615,7 @@
         <property name="source" ref="DYN_17_1369664356511DataSource" />
         <property name="appearance" ref="DYN_17_1369664356511Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5462,6 +5629,7 @@
         <property name="source" ref="DYN_17_1369727728084DataSource" />
         <property name="appearance" ref="DYN_17_1369727728084Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5475,6 +5643,7 @@
         <property name="source" ref="DYN_17_1369841595246DataSource" />
         <property name="appearance" ref="DYN_17_1369841595246Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5488,6 +5657,7 @@
         <property name="source" ref="DYN_17_1370248326413DataSource" />
         <property name="appearance" ref="DYN_17_1370248326413Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5501,6 +5671,7 @@
         <property name="source" ref="DYN_17_1370268433786DataSource" />
         <property name="appearance" ref="DYN_17_1370268433786Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5514,6 +5685,7 @@
         <property name="source" ref="DYN_17_1370331977802DataSource" />
         <property name="appearance" ref="DYN_17_1370331977802Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5527,6 +5699,7 @@
         <property name="source" ref="DYN_17_1370339370321DataSource" />
         <property name="appearance" ref="DYN_17_1370339370321Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5540,6 +5713,7 @@
         <property name="source" ref="DYN_17_1370346706787DataSource" />
         <property name="appearance" ref="DYN_17_1370346706787Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5553,6 +5727,7 @@
         <property name="source" ref="DYN_17_1370347864927DataSource" />
         <property name="appearance" ref="DYN_17_1370347864927Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5566,6 +5741,7 @@
         <property name="source" ref="DYN_17_1370358118751DataSource" />
         <property name="appearance" ref="DYN_17_1370358118751Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5579,6 +5755,7 @@
         <property name="source" ref="DYN_17_1370437834297DataSource" />
         <property name="appearance" ref="DYN_17_1370437834297Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5592,6 +5769,7 @@
         <property name="source" ref="DYN_17_1370522051248DataSource" />
         <property name="appearance" ref="DYN_17_1370522051248Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5605,6 +5783,7 @@
         <property name="source" ref="DYN_17_1370524783155DataSource" />
         <property name="appearance" ref="DYN_17_1370524783155Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5618,6 +5797,7 @@
         <property name="source" ref="DYN_17_1370616707097DataSource" />
         <property name="appearance" ref="DYN_17_1370616707097Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5631,6 +5811,7 @@
         <property name="source" ref="DYN_17_1370616707230DataSource" />
         <property name="appearance" ref="DYN_17_1370616707230Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5644,6 +5825,7 @@
         <property name="source" ref="DYN_17_1371032794782DataSource" />
         <property name="appearance" ref="DYN_17_1371032794782Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5657,6 +5839,7 @@
         <property name="source" ref="DYN_17_1371145490632DataSource" />
         <property name="appearance" ref="DYN_17_1371145490632Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5670,6 +5853,7 @@
         <property name="source" ref="DYN_17_1375109485576DataSource" />
         <property name="appearance" ref="DYN_17_1375109485576Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5683,6 +5867,7 @@
         <property name="source" ref="DYN_17_1377852947018DataSource" />
         <property name="appearance" ref="DYN_17_1377852947018Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5696,6 +5881,7 @@
         <property name="source" ref="DYN_17_1441115410183DataSource" />
         <property name="appearance" ref="DYN_17_1441115410183Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5709,6 +5895,7 @@
         <property name="source" ref="DYN_17_1441204749960DataSource" />
         <property name="appearance" ref="DYN_17_1441204749960Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5722,6 +5909,7 @@
         <property name="source" ref="DYN_17_1441206453307DataSource" />
         <property name="appearance" ref="DYN_17_1441206453307Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5735,6 +5923,7 @@
         <property name="source" ref="DYN_17_1441291537965DataSource" />
         <property name="appearance" ref="DYN_17_1441291537965Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5748,6 +5937,7 @@
         <property name="source" ref="DYN_17_1441765273807DataSource" />
         <property name="appearance" ref="DYN_17_1441765273807Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5761,6 +5951,7 @@
         <property name="source" ref="DYN_17_1448369691146DataSource" />
         <property name="appearance" ref="DYN_17_1448369691146Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5774,6 +5965,7 @@
         <property name="source" ref="DYN_17_1452004915902DataSource" />
         <property name="appearance" ref="DYN_17_1452004915902Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5787,6 +5979,7 @@
         <property name="source" ref="DYN_17_1456828579111DataSource" />
         <property name="appearance" ref="DYN_17_1456828579111Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5800,6 +5993,7 @@
         <property name="source" ref="DYN_17_1460710398304DataSource" />
         <property name="appearance" ref="DYN_17_1460710398304Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5813,6 +6007,7 @@
         <property name="source" ref="DYN_18_1369735107391DataSource" />
         <property name="appearance" ref="DYN_18_1369735107391Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5826,6 +6021,7 @@
         <property name="source" ref="DYN_18_1370524532333DataSource" />
         <property name="appearance" ref="DYN_18_1370524532333Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5839,6 +6035,7 @@
         <property name="source" ref="DYN_18_1440594802970DataSource" />
         <property name="appearance" ref="DYN_18_1440594802970Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5852,6 +6049,7 @@
         <property name="source" ref="DYN_18_1440594848358DataSource" />
         <property name="appearance" ref="DYN_18_1440594848358Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5865,6 +6063,7 @@
         <property name="source" ref="DYN_18_1440594885950DataSource" />
         <property name="appearance" ref="DYN_18_1440594885950Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5878,6 +6077,7 @@
         <property name="source" ref="DYN_18_1440594891555DataSource" />
         <property name="appearance" ref="DYN_18_1440594891555Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5891,6 +6091,7 @@
         <property name="source" ref="DYN_83_1369390411276DataSource" />
         <property name="appearance" ref="DYN_83_1369390411276Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5904,6 +6105,7 @@
         <property name="source" ref="DYN_87_1370339367236DataSource" />
         <property name="appearance" ref="DYN_87_1370339367236Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5917,6 +6119,7 @@
         <property name="source" ref="DYN_89_1371032799773DataSource" />
         <property name="appearance" ref="DYN_89_1371032799773Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5930,6 +6133,7 @@
         <property name="source" ref="DYN_93_1370347899084DataSource" />
         <property name="appearance" ref="DYN_93_1370347899084Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5943,6 +6147,7 @@
         <property name="source" ref="DYN_93_1370614843635DataSource" />
         <property name="appearance" ref="DYN_93_1370614843635Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5956,6 +6161,7 @@
         <property name="source" ref="geopicsDataSource" />
         <property name="appearance" ref="geopicsAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5969,6 +6175,7 @@
         <property name="source" ref="ammoniumDataSource" />
         <property name="appearance" ref="ammoniumAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5982,6 +6189,7 @@
         <property name="source" ref="locations_masterDataSource" />
         <property name="appearance" ref="locations_masterAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -6000,7 +6208,7 @@
                 <ref bean="01_kharaa_river_basin_32648" />
                 <ref bean="01_kharaa_subbasins_32648" />
                 <ref bean="02_surface_water_bodies_32648" />
-                <ref bean="02_surface_water_bodies_corr_32648" />
+                <!-- <ref bean="02_surface_water_bodies_corr_32648" />
                 <ref bean="03_groundwater_bodies_32648" />
                 <ref bean="03_groundwater_monitoring_sites_32648" />
                 <ref bean="07_mining_operations_32648" />
@@ -6204,7 +6412,7 @@
                 <ref bean="locations_master" />
                 <ref bean="mongoliaStateCenters" />
                 <ref bean="osmTopo" />
-                <ref bean="osmWmsLayer" />
+                <ref bean="osmWmsLayer" />-->
                 <ref bean="osmWmsLayerGray" />
 
             </util:list>
@@ -6284,6 +6492,17 @@
         </property>
     </bean>
 
+    <bean id="hsiToolsModule" class="de.terrestris.shogun2.model.module.Button">
+        <property name="name" value="Activate hover-select tool" />
+        <property name="xtype" value="basigx-button-hsi" />
+        <property name="properties">
+             <util:map>
+                <entry key="scale" value="small" />
+                <entry key="ui" value="default" />
+             </util:map>
+        </property>
+    </bean>
+
     <bean id="showMeasureToolsModule" class="de.terrestris.shogun2.model.module.Button">
         <property name="name" value="Show measure tools button" />
         <property name="xtype" value="momo-button-showmeasuretoolspanel" />
@@ -6342,6 +6561,7 @@
                 <ref bean="zoomToExtentModule" />
                 <ref bean="stepBackModule" />
                 <ref bean="stepForwardModule" />
+                <ref bean="hsiToolsModule" />
                 <ref bean="showMeasureToolsModule" />
                 <ref bean="showRedliningToolsModule" />
             </util:list>

--- a/src/main/resources/META-INF/spring/dev/momo-context-initialize-beans.xml
+++ b/src/main/resources/META-INF/spring/dev/momo-context-initialize-beans.xml
@@ -274,6 +274,7 @@
         <ref bean="zoomToExtentModule" />
         <ref bean="stepBackModule" />
         <ref bean="stepForwardModule" />
+        <ref bean="hsiToolsModule" />
         <ref bean="showMeasureToolsModule" />
         <ref bean="showRedliningToolsModule" />
 
@@ -3304,6 +3305,7 @@
         <property name="source" ref="mongoliaStateCentersDataSource" />
         <property name="appearance" ref="mongoliaStateCentersAppearance" />
         <property name="spatiallyRestricted" value="true" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3317,6 +3319,7 @@
         <property name="source" ref="osmTopoDataSource" />
         <property name="appearance" ref="osmTopoAppearance" />
         <property name="spatiallyRestricted" value="true" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3330,6 +3333,7 @@
         <property name="source" ref="01_kharaa_river_basin_32648DataSource" />
         <property name="appearance" ref="01_kharaa_river_basin_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3343,6 +3347,7 @@
         <property name="source" ref="01_kharaa_subbasins_32648DataSource" />
         <property name="appearance" ref="01_kharaa_subbasins_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3356,6 +3361,7 @@
         <property name="source" ref="02_surface_water_bodies_32648DataSource" />
         <property name="appearance" ref="02_surface_water_bodies_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3369,6 +3375,7 @@
         <property name="source" ref="02_surface_water_bodies_corr_32648DataSource" />
         <property name="appearance" ref="02_surface_water_bodies_corr_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3382,6 +3389,7 @@
         <property name="source" ref="03_groundwater_bodies_32648DataSource" />
         <property name="appearance" ref="03_groundwater_bodies_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3395,6 +3403,7 @@
         <property name="source" ref="03_groundwater_monitoring_sites_32648DataSource" />
         <property name="appearance" ref="03_groundwater_monitoring_sites_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3408,6 +3417,7 @@
         <property name="source" ref="07_mining_operations_32648DataSource" />
         <property name="appearance" ref="07_mining_operations_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3421,6 +3431,7 @@
         <property name="source" ref="07_potentially_contaminated_areas_32648DataSource" />
         <property name="appearance" ref="07_potentially_contaminated_areas_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3434,6 +3445,7 @@
         <property name="source" ref="07_risk_assessment_groundwater_bodies_32648DataSource" />
         <property name="appearance" ref="07_risk_assessment_groundwater_bodies_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3447,6 +3459,7 @@
         <property name="source" ref="07_risk_assessment_surface_water_bodies_32648DataSource" />
         <property name="appearance" ref="07_risk_assessment_surface_water_bodies_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3460,6 +3473,7 @@
         <property name="source" ref="2085_prec_sum_mngDataSource" />
         <property name="appearance" ref="2085_prec_sum_mngAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3473,6 +3487,7 @@
         <property name="source" ref="aet_1971-00DataSource" />
         <property name="appearance" ref="aet_1971-00Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3486,6 +3501,7 @@
         <property name="source" ref="aimag_boundaryDataSource" />
         <property name="appearance" ref="aimag_boundaryAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3499,6 +3515,7 @@
         <property name="source" ref="aimag_centerDataSource" />
         <property name="appearance" ref="aimag_centerAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3512,6 +3529,7 @@
         <property name="source" ref="aimagboundaryDataSource" />
         <property name="appearance" ref="aimagboundaryAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3525,6 +3543,7 @@
         <property name="source" ref="avail_1971-00DataSource" />
         <property name="appearance" ref="avail_1971-00Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3538,6 +3557,7 @@
         <property name="source" ref="avail_2011-40_a2_cncm3DataSource" />
         <property name="appearance" ref="avail_2011-40_a2_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3551,6 +3571,7 @@
         <property name="source" ref="avail_2011-40_a2_echam5DataSource" />
         <property name="appearance" ref="avail_2011-40_a2_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3564,6 +3585,7 @@
         <property name="source" ref="avail_2011-40_a2_ipslDataSource" />
         <property name="appearance" ref="avail_2011-40_a2_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3577,6 +3599,7 @@
         <property name="source" ref="avail_2011-40_b1_cncm3DataSource" />
         <property name="appearance" ref="avail_2011-40_b1_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3590,6 +3613,7 @@
         <property name="source" ref="avail_2011-40_b1_echam5DataSource" />
         <property name="appearance" ref="avail_2011-40_b1_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3603,6 +3627,7 @@
         <property name="source" ref="avail_2011-40_b1_ipslDataSource" />
         <property name="appearance" ref="avail_2011-40_b1_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3616,6 +3641,7 @@
         <property name="source" ref="avail_2041-70_a2_cncm3DataSource" />
         <property name="appearance" ref="avail_2041-70_a2_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3629,6 +3655,7 @@
         <property name="source" ref="avail_2041-70_a2_echam5DataSource" />
         <property name="appearance" ref="avail_2041-70_a2_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3642,6 +3669,7 @@
         <property name="source" ref="avail_2041-70_a2_ipslDataSource" />
         <property name="appearance" ref="avail_2041-70_a2_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3655,6 +3683,7 @@
         <property name="source" ref="avail_2041-70_b1_cncm3DataSource" />
         <property name="appearance" ref="avail_2041-70_b1_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3668,6 +3697,7 @@
         <property name="source" ref="avail_2041-70_b1_echam5DataSource" />
         <property name="appearance" ref="avail_2041-70_b1_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3681,6 +3711,7 @@
         <property name="source" ref="avail_2041-70_b1_ipslDataSource" />
         <property name="appearance" ref="avail_2041-70_b1_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3694,6 +3725,7 @@
         <property name="source" ref="avail_2071-00_a2_cncm3DataSource" />
         <property name="appearance" ref="avail_2071-00_a2_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3707,6 +3739,7 @@
         <property name="source" ref="avail_2071-00_a2_echam5DataSource" />
         <property name="appearance" ref="avail_2071-00_a2_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3720,6 +3753,7 @@
         <property name="source" ref="avail_2071-00_a2_ipslDataSource" />
         <property name="appearance" ref="avail_2071-00_a2_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3733,6 +3767,7 @@
         <property name="source" ref="avail_2071-00_b1_cncm3DataSource" />
         <property name="appearance" ref="avail_2071-00_b1_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3746,6 +3781,7 @@
         <property name="source" ref="avail_2071-00_b1_echam5DataSource" />
         <property name="appearance" ref="avail_2071-00_b1_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3759,6 +3795,7 @@
         <property name="source" ref="avail_2071-00_b1_ipslDataSource" />
         <property name="appearance" ref="avail_2071-00_b1_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3772,6 +3809,7 @@
         <property name="source" ref="big_riversDataSource" />
         <property name="appearance" ref="big_riversAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3785,6 +3823,7 @@
         <property name="source" ref="blue_marbleDataSource" />
         <property name="appearance" ref="blue_marbleAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3798,6 +3837,7 @@
         <property name="source" ref="buildingsDataSource" />
         <property name="appearance" ref="buildingsAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3811,6 +3851,7 @@
         <property name="source" ref="country_bordersDataSource" />
         <property name="appearance" ref="country_bordersAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3824,6 +3865,7 @@
         <property name="source" ref="cropland_1989_kharaaDataSource" />
         <property name="appearance" ref="cropland_1989_kharaaAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3837,6 +3879,7 @@
         <property name="source" ref="cropland_2006_kharaaDataSource" />
         <property name="appearance" ref="cropland_2006_kharaaAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3850,6 +3893,7 @@
         <property name="source" ref="DEM_30mDataSource" />
         <property name="appearance" ref="DEM_30mAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3863,6 +3907,7 @@
         <property name="source" ref="DEM_Mongolia_900mDataSource" />
         <property name="appearance" ref="DEM_Mongolia_900mAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3876,6 +3921,7 @@
         <property name="source" ref="digiriver_subbasinsDataSource" />
         <property name="appearance" ref="digiriver_subbasinsAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3889,6 +3935,7 @@
         <property name="source" ref="dyn_17_1369841595246DataSource" />
         <property name="appearance" ref="dyn_17_1369841595246Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3902,6 +3949,7 @@
         <property name="source" ref="ecological_status_kharaaDataSource" />
         <property name="appearance" ref="ecological_status_kharaaAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3915,6 +3963,7 @@
         <property name="source" ref="ecological_status_kharaa_uploadtestDataSource" />
         <property name="appearance" ref="ecological_status_kharaa_uploadtestAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3928,6 +3977,7 @@
         <property name="source" ref="einwohnerdichteDataSource" />
         <property name="appearance" ref="einwohnerdichteAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3941,6 +3991,7 @@
         <property name="source" ref="einwohnerdichte_darhanDataSource" />
         <property name="appearance" ref="einwohnerdichte_darhanAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3954,6 +4005,7 @@
         <property name="source" ref="gebaeudeDataSource" />
         <property name="appearance" ref="gebaeudeAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3967,6 +4019,7 @@
         <property name="source" ref="gebaeude_darkhan_32648_clipDataSource" />
         <property name="appearance" ref="gebaeude_darkhan_32648_clipAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3980,6 +4033,7 @@
         <property name="source" ref="gebaeude_darkhan_32648_clip_tryDataSource" />
         <property name="appearance" ref="gebaeude_darkhan_32648_clip_tryAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3993,6 +4047,7 @@
         <property name="source" ref="gebaeude1_darhanDataSource" />
         <property name="appearance" ref="gebaeude1_darhanAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4006,6 +4061,7 @@
         <property name="source" ref="golDataSource" />
         <property name="appearance" ref="golAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4019,6 +4075,7 @@
         <property name="source" ref="kharaa_basinDataSource" />
         <property name="appearance" ref="kharaa_basinAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4032,6 +4089,7 @@
         <property name="source" ref="kharaa_darhanDataSource" />
         <property name="appearance" ref="kharaa_darhanAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4045,6 +4103,7 @@
         <property name="source" ref="kharaa_subbasinsDataSource" />
         <property name="appearance" ref="kharaa_subbasinsAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4058,6 +4117,7 @@
         <property name="source" ref="lakes_largeDataSource" />
         <property name="appearance" ref="lakes_largeAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4071,6 +4131,7 @@
         <property name="source" ref="landuseDataSource" />
         <property name="appearance" ref="landuseAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4084,6 +4145,7 @@
         <property name="source" ref="mng_roadsDataSource" />
         <property name="appearance" ref="mng_roadsAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4097,6 +4159,7 @@
         <property name="source" ref="naturalDataSource" />
         <property name="appearance" ref="naturalAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4110,6 +4173,7 @@
         <property name="source" ref="nuuruudDataSource" />
         <property name="appearance" ref="nuuruudAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4123,6 +4187,7 @@
         <property name="source" ref="ortho_drone_oczipkaDataSource" />
         <property name="appearance" ref="ortho_drone_oczipkaAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4136,6 +4201,7 @@
         <property name="source" ref="permafrostDataSource" />
         <property name="appearance" ref="permafrostAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4149,6 +4215,7 @@
         <property name="source" ref="phenomenonzonemetaDataSource" />
         <property name="appearance" ref="phenomenonzonemetaAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4162,6 +4229,7 @@
         <property name="source" ref="placesDataSource" />
         <property name="appearance" ref="placesAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4175,6 +4243,7 @@
         <property name="source" ref="pointsDataSource" />
         <property name="appearance" ref="pointsAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4188,6 +4257,7 @@
         <property name="source" ref="populationdensity_darhanDataSource" />
         <property name="appearance" ref="populationdensity_darhanAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4201,6 +4271,7 @@
         <property name="source" ref="precip_1971-00DataSource" />
         <property name="appearance" ref="precip_1971-00Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4214,6 +4285,7 @@
         <property name="source" ref="precip_2011-40_a2_cncm3DataSource" />
         <property name="appearance" ref="precip_2011-40_a2_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4227,6 +4299,7 @@
         <property name="source" ref="precip_2011-40_a2_echam5DataSource" />
         <property name="appearance" ref="precip_2011-40_a2_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4240,6 +4313,7 @@
         <property name="source" ref="precip_2011-40_a2_ipslDataSource" />
         <property name="appearance" ref="precip_2011-40_a2_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4253,6 +4327,7 @@
         <property name="source" ref="precip_2011-40_b1_cncm3DataSource" />
         <property name="appearance" ref="precip_2011-40_b1_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4266,6 +4341,7 @@
         <property name="source" ref="precip_2011-40_b1_echam5DataSource" />
         <property name="appearance" ref="precip_2011-40_b1_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4279,6 +4355,7 @@
         <property name="source" ref="precip_2011-40_b1_ipslDataSource" />
         <property name="appearance" ref="precip_2011-40_b1_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4292,6 +4369,7 @@
         <property name="source" ref="precip_2041-70_a2_cncm3DataSource" />
         <property name="appearance" ref="precip_2041-70_a2_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4305,6 +4383,7 @@
         <property name="source" ref="precip_2041-70_a2_echam5DataSource" />
         <property name="appearance" ref="precip_2041-70_a2_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4318,6 +4397,7 @@
         <property name="source" ref="precip_2041-70_a2_ipslDataSource" />
         <property name="appearance" ref="precip_2041-70_a2_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4331,6 +4411,7 @@
         <property name="source" ref="precip_2041-70_b1_cncm3DataSource" />
         <property name="appearance" ref="precip_2041-70_b1_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4344,6 +4425,7 @@
         <property name="source" ref="precip_2041-70_b1_echam5DataSource" />
         <property name="appearance" ref="precip_2041-70_b1_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4357,6 +4439,7 @@
         <property name="source" ref="precip_2041-70_b1_ipslDataSource" />
         <property name="appearance" ref="precip_2041-70_b1_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4370,6 +4453,7 @@
         <property name="source" ref="precip_2071-00_a2_cncm3DataSource" />
         <property name="appearance" ref="precip_2071-00_a2_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4383,6 +4467,7 @@
         <property name="source" ref="precip_2071-00_a2_echam5DataSource" />
         <property name="appearance" ref="precip_2071-00_a2_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4396,6 +4481,7 @@
         <property name="source" ref="precip_2071-00_a2_ipslDataSource" />
         <property name="appearance" ref="precip_2071-00_a2_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4409,6 +4495,7 @@
         <property name="source" ref="precip_2071-00_b1_cncm3DataSource" />
         <property name="appearance" ref="precip_2071-00_b1_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4422,6 +4509,7 @@
         <property name="source" ref="precip_2071-00_b1_echam5DataSource" />
         <property name="appearance" ref="precip_2071-00_b1_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4435,6 +4523,7 @@
         <property name="source" ref="precip_2071-00_b1_ipslDataSource" />
         <property name="appearance" ref="precip_2071-00_b1_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4448,6 +4537,7 @@
         <property name="source" ref="protected_areasDataSource" />
         <property name="appearance" ref="protected_areasAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4461,6 +4551,7 @@
         <property name="source" ref="rail_roadDataSource" />
         <property name="appearance" ref="rail_roadAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4474,6 +4565,7 @@
         <property name="source" ref="railwaysDataSource" />
         <property name="appearance" ref="railwaysAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4487,6 +4579,7 @@
         <property name="source" ref="roadsDataSource" />
         <property name="appearance" ref="roadsAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4500,6 +4593,7 @@
         <property name="source" ref="snow_cover_fraction_1971-00DataSource" />
         <property name="appearance" ref="snow_cover_fraction_1971-00Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4513,6 +4607,7 @@
         <property name="source" ref="soum_center342DataSource" />
         <property name="appearance" ref="soum_center342Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4526,6 +4621,7 @@
         <property name="source" ref="state_boundaryDataSource" />
         <property name="appearance" ref="state_boundaryAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4539,6 +4635,7 @@
         <property name="source" ref="temp_1971-00DataSource" />
         <property name="appearance" ref="temp_1971-00Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4552,6 +4649,7 @@
         <property name="source" ref="temp_2011-40_a2_cncm3DataSource" />
         <property name="appearance" ref="temp_2011-40_a2_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4565,6 +4663,7 @@
         <property name="source" ref="temp_2011-40_a2_echam5DataSource" />
         <property name="appearance" ref="temp_2011-40_a2_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4578,6 +4677,7 @@
         <property name="source" ref="temp_2011-40_a2_ipslDataSource" />
         <property name="appearance" ref="temp_2011-40_a2_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4591,6 +4691,7 @@
         <property name="source" ref="temp_2011-40_b1_cncm3DataSource" />
         <property name="appearance" ref="temp_2011-40_b1_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4604,6 +4705,7 @@
         <property name="source" ref="temp_2011-40_b1_echam5DataSource" />
         <property name="appearance" ref="temp_2011-40_b1_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4617,6 +4719,7 @@
         <property name="source" ref="temp_2011-40_b1_ipslDataSource" />
         <property name="appearance" ref="temp_2011-40_b1_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4630,6 +4733,7 @@
         <property name="source" ref="temp_2041-70_a2_cncm3DataSource" />
         <property name="appearance" ref="temp_2041-70_a2_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4643,6 +4747,7 @@
         <property name="source" ref="temp_2041-70_a2_echam5DataSource" />
         <property name="appearance" ref="temp_2041-70_a2_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4656,6 +4761,7 @@
         <property name="source" ref="temp_2041-70_a2_ipslDataSource" />
         <property name="appearance" ref="temp_2041-70_a2_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4669,6 +4775,7 @@
         <property name="source" ref="temp_2041-70_b1_cncm3DataSource" />
         <property name="appearance" ref="temp_2041-70_b1_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4682,6 +4789,7 @@
         <property name="source" ref="temp_2041-70_b1_echam5DataSource" />
         <property name="appearance" ref="temp_2041-70_b1_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4695,6 +4803,7 @@
         <property name="source" ref="temp_2041-70_b1_ipslDataSource" />
         <property name="appearance" ref="temp_2041-70_b1_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4708,6 +4817,7 @@
         <property name="source" ref="temp_2071-00_a2_cncm3DataSource" />
         <property name="appearance" ref="temp_2071-00_a2_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4721,6 +4831,7 @@
         <property name="source" ref="temp_2071-00_a2_echam5DataSource" />
         <property name="appearance" ref="temp_2071-00_a2_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4734,6 +4845,7 @@
         <property name="source" ref="temp_2071-00_a2_ipslDataSource" />
         <property name="appearance" ref="temp_2071-00_a2_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4747,6 +4859,7 @@
         <property name="source" ref="temp_2071-00_b1_cncm3DataSource" />
         <property name="appearance" ref="temp_2071-00_b1_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4760,6 +4873,7 @@
         <property name="source" ref="temp_2071-00_b1_echam5DataSource" />
         <property name="appearance" ref="temp_2071-00_b1_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4773,6 +4887,7 @@
         <property name="source" ref="temp_2071-00_b1_ipslDataSource" />
         <property name="appearance" ref="temp_2071-00_b1_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4786,6 +4901,7 @@
         <property name="source" ref="TM5_2010DataSource" />
         <property name="appearance" ref="TM5_2010Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4799,6 +4915,7 @@
         <property name="source" ref="wasserkioske_bag7_32648DataSource" />
         <property name="appearance" ref="wasserkioske_bag7_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4812,6 +4929,7 @@
         <property name="source" ref="wastewater_darhanDataSource" />
         <property name="appearance" ref="wastewater_darhanAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4825,6 +4943,7 @@
         <property name="source" ref="waterwaysDataSource" />
         <property name="appearance" ref="waterwaysAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4838,6 +4957,7 @@
         <property name="source" ref="wg3_webgis_cruDataSource" />
         <property name="appearance" ref="wg3_webgis_cruAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4851,6 +4971,7 @@
         <property name="source" ref="DYN_109_1369735105591DataSource" />
         <property name="appearance" ref="DYN_109_1369735105591Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4864,6 +4985,7 @@
         <property name="source" ref="DYN_109_1369742468725DataSource" />
         <property name="appearance" ref="DYN_109_1369742468725Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4877,6 +4999,7 @@
         <property name="source" ref="DYN_109_1369841716922DataSource" />
         <property name="appearance" ref="DYN_109_1369841716922Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4890,6 +5013,7 @@
         <property name="source" ref="DYN_13_1365601378477DataSource" />
         <property name="appearance" ref="DYN_13_1365601378477Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4903,6 +5027,7 @@
         <property name="source" ref="DYN_13_1365601542355DataSource" />
         <property name="appearance" ref="DYN_13_1365601542355Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4916,6 +5041,7 @@
         <property name="source" ref="DYN_14_1365602120228DataSource" />
         <property name="appearance" ref="DYN_14_1365602120228Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4929,6 +5055,7 @@
         <property name="source" ref="DYN_14_1365605442839DataSource" />
         <property name="appearance" ref="DYN_14_1365605442839Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4942,6 +5069,7 @@
         <property name="source" ref="DYN_14_1365605456216DataSource" />
         <property name="appearance" ref="DYN_14_1365605456216Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4955,6 +5083,7 @@
         <property name="source" ref="DYN_14_1365605476506DataSource" />
         <property name="appearance" ref="DYN_14_1365605476506Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4968,6 +5097,7 @@
         <property name="source" ref="DYN_14_1365605781970DataSource" />
         <property name="appearance" ref="DYN_14_1365605781970Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4981,6 +5111,7 @@
         <property name="source" ref="DYN_14_1365605882959DataSource" />
         <property name="appearance" ref="DYN_14_1365605882959Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4994,6 +5125,7 @@
         <property name="source" ref="DYN_14_1365605890897DataSource" />
         <property name="appearance" ref="DYN_14_1365605890897Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5007,6 +5139,7 @@
         <property name="source" ref="DYN_14_1365605955459DataSource" />
         <property name="appearance" ref="DYN_14_1365605955459Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5020,6 +5153,7 @@
         <property name="source" ref="DYN_14_1365605978459DataSource" />
         <property name="appearance" ref="DYN_14_1365605978459Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5033,6 +5167,7 @@
         <property name="source" ref="DYN_14_1365605987568DataSource" />
         <property name="appearance" ref="DYN_14_1365605987568Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5046,6 +5181,7 @@
         <property name="source" ref="DYN_14_1365605992016DataSource" />
         <property name="appearance" ref="DYN_14_1365605992016Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5059,6 +5195,7 @@
         <property name="source" ref="DYN_14_1365605995942DataSource" />
         <property name="appearance" ref="DYN_14_1365605995942Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5072,6 +5209,7 @@
         <property name="source" ref="DYN_14_1365608956030DataSource" />
         <property name="appearance" ref="DYN_14_1365608956030Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5085,6 +5223,7 @@
         <property name="source" ref="DYN_14_1365694916518DataSource" />
         <property name="appearance" ref="DYN_14_1365694916518Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5098,6 +5237,7 @@
         <property name="source" ref="DYN_14_1365759012080DataSource" />
         <property name="appearance" ref="DYN_14_1365759012080Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5111,6 +5251,7 @@
         <property name="source" ref="DYN_14_1365759879641DataSource" />
         <property name="appearance" ref="DYN_14_1365759879641Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5124,6 +5265,7 @@
         <property name="source" ref="DYN_14_1365760699624DataSource" />
         <property name="appearance" ref="DYN_14_1365760699624Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5137,6 +5279,7 @@
         <property name="source" ref="DYN_14_1365761490659DataSource" />
         <property name="appearance" ref="DYN_14_1365761490659Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5150,6 +5293,7 @@
         <property name="source" ref="DYN_14_1365761504280DataSource" />
         <property name="appearance" ref="DYN_14_1365761504280Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5163,6 +5307,7 @@
         <property name="source" ref="DYN_14_1366635679454DataSource" />
         <property name="appearance" ref="DYN_14_1366635679454Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5176,6 +5321,7 @@
         <property name="source" ref="DYN_14_1366635904632DataSource" />
         <property name="appearance" ref="DYN_14_1366635904632Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5189,6 +5335,7 @@
         <property name="source" ref="DYN_14_1366704342968DataSource" />
         <property name="appearance" ref="DYN_14_1366704342968Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5202,6 +5349,7 @@
         <property name="source" ref="DYN_14_1367228008564DataSource" />
         <property name="appearance" ref="DYN_14_1367228008564Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5215,6 +5363,7 @@
         <property name="source" ref="DYN_14_1367848456001DataSource" />
         <property name="appearance" ref="DYN_14_1367848456001Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5228,6 +5377,7 @@
         <property name="source" ref="DYN_14_1367938733533DataSource" />
         <property name="appearance" ref="DYN_14_1367938733533Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5241,6 +5391,7 @@
         <property name="source" ref="DYN_14_1368001502620DataSource" />
         <property name="appearance" ref="DYN_14_1368001502620Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5254,6 +5405,7 @@
         <property name="source" ref="DYN_14_1368001531956DataSource" />
         <property name="appearance" ref="DYN_14_1368001531956Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5267,6 +5419,7 @@
         <property name="source" ref="DYN_14_1368431465466DataSource" />
         <property name="appearance" ref="DYN_14_1368431465466Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5280,6 +5433,7 @@
         <property name="source" ref="DYN_14_1369216335515DataSource" />
         <property name="appearance" ref="DYN_14_1369216335515Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5293,6 +5447,7 @@
         <property name="source" ref="DYN_14_1369390350022DataSource" />
         <property name="appearance" ref="DYN_14_1369390350022Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5306,6 +5461,7 @@
         <property name="source" ref="DYN_14_1369657232648DataSource" />
         <property name="appearance" ref="DYN_14_1369657232648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5319,6 +5475,7 @@
         <property name="source" ref="DYN_15_1365608726707DataSource" />
         <property name="appearance" ref="DYN_15_1365608726707Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5332,6 +5489,7 @@
         <property name="source" ref="DYN_15_1365608732880DataSource" />
         <property name="appearance" ref="DYN_15_1365608732880Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5345,6 +5503,7 @@
         <property name="source" ref="DYN_15_1365608753118DataSource" />
         <property name="appearance" ref="DYN_15_1365608753118Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5358,6 +5517,7 @@
         <property name="source" ref="DYN_15_1365608802067DataSource" />
         <property name="appearance" ref="DYN_15_1365608802067Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5371,6 +5531,7 @@
         <property name="source" ref="DYN_15_1365608806430DataSource" />
         <property name="appearance" ref="DYN_15_1365608806430Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5384,6 +5545,7 @@
         <property name="source" ref="DYN_15_1365610632020DataSource" />
         <property name="appearance" ref="DYN_15_1365610632020Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5397,6 +5559,7 @@
         <property name="source" ref="DYN_17_1369658293805DataSource" />
         <property name="appearance" ref="DYN_17_1369658293805Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5410,6 +5573,7 @@
         <property name="source" ref="DYN_17_1369661200358DataSource" />
         <property name="appearance" ref="DYN_17_1369661200358Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5423,6 +5587,7 @@
         <property name="source" ref="DYN_17_1369663868865DataSource" />
         <property name="appearance" ref="DYN_17_1369663868865Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5436,6 +5601,7 @@
         <property name="source" ref="DYN_17_1369664218638DataSource" />
         <property name="appearance" ref="DYN_17_1369664218638Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5449,6 +5615,7 @@
         <property name="source" ref="DYN_17_1369664356511DataSource" />
         <property name="appearance" ref="DYN_17_1369664356511Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5462,6 +5629,7 @@
         <property name="source" ref="DYN_17_1369727728084DataSource" />
         <property name="appearance" ref="DYN_17_1369727728084Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5475,6 +5643,7 @@
         <property name="source" ref="DYN_17_1369841595246DataSource" />
         <property name="appearance" ref="DYN_17_1369841595246Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5488,6 +5657,7 @@
         <property name="source" ref="DYN_17_1370248326413DataSource" />
         <property name="appearance" ref="DYN_17_1370248326413Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5501,6 +5671,7 @@
         <property name="source" ref="DYN_17_1370268433786DataSource" />
         <property name="appearance" ref="DYN_17_1370268433786Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5514,6 +5685,7 @@
         <property name="source" ref="DYN_17_1370331977802DataSource" />
         <property name="appearance" ref="DYN_17_1370331977802Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5527,6 +5699,7 @@
         <property name="source" ref="DYN_17_1370339370321DataSource" />
         <property name="appearance" ref="DYN_17_1370339370321Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5540,6 +5713,7 @@
         <property name="source" ref="DYN_17_1370346706787DataSource" />
         <property name="appearance" ref="DYN_17_1370346706787Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5553,6 +5727,7 @@
         <property name="source" ref="DYN_17_1370347864927DataSource" />
         <property name="appearance" ref="DYN_17_1370347864927Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5566,6 +5741,7 @@
         <property name="source" ref="DYN_17_1370358118751DataSource" />
         <property name="appearance" ref="DYN_17_1370358118751Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5579,6 +5755,7 @@
         <property name="source" ref="DYN_17_1370437834297DataSource" />
         <property name="appearance" ref="DYN_17_1370437834297Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5592,6 +5769,7 @@
         <property name="source" ref="DYN_17_1370522051248DataSource" />
         <property name="appearance" ref="DYN_17_1370522051248Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5605,6 +5783,7 @@
         <property name="source" ref="DYN_17_1370524783155DataSource" />
         <property name="appearance" ref="DYN_17_1370524783155Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5618,6 +5797,7 @@
         <property name="source" ref="DYN_17_1370616707097DataSource" />
         <property name="appearance" ref="DYN_17_1370616707097Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5631,6 +5811,7 @@
         <property name="source" ref="DYN_17_1370616707230DataSource" />
         <property name="appearance" ref="DYN_17_1370616707230Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5644,6 +5825,7 @@
         <property name="source" ref="DYN_17_1371032794782DataSource" />
         <property name="appearance" ref="DYN_17_1371032794782Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5657,6 +5839,7 @@
         <property name="source" ref="DYN_17_1371145490632DataSource" />
         <property name="appearance" ref="DYN_17_1371145490632Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5670,6 +5853,7 @@
         <property name="source" ref="DYN_17_1375109485576DataSource" />
         <property name="appearance" ref="DYN_17_1375109485576Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5683,6 +5867,7 @@
         <property name="source" ref="DYN_17_1377852947018DataSource" />
         <property name="appearance" ref="DYN_17_1377852947018Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5696,6 +5881,7 @@
         <property name="source" ref="DYN_17_1441115410183DataSource" />
         <property name="appearance" ref="DYN_17_1441115410183Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5709,6 +5895,7 @@
         <property name="source" ref="DYN_17_1441204749960DataSource" />
         <property name="appearance" ref="DYN_17_1441204749960Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5722,6 +5909,7 @@
         <property name="source" ref="DYN_17_1441206453307DataSource" />
         <property name="appearance" ref="DYN_17_1441206453307Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5735,6 +5923,7 @@
         <property name="source" ref="DYN_17_1441291537965DataSource" />
         <property name="appearance" ref="DYN_17_1441291537965Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5748,6 +5937,7 @@
         <property name="source" ref="DYN_17_1441765273807DataSource" />
         <property name="appearance" ref="DYN_17_1441765273807Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5761,6 +5951,7 @@
         <property name="source" ref="DYN_17_1448369691146DataSource" />
         <property name="appearance" ref="DYN_17_1448369691146Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5774,6 +5965,7 @@
         <property name="source" ref="DYN_17_1452004915902DataSource" />
         <property name="appearance" ref="DYN_17_1452004915902Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5787,6 +5979,7 @@
         <property name="source" ref="DYN_17_1456828579111DataSource" />
         <property name="appearance" ref="DYN_17_1456828579111Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5800,6 +5993,7 @@
         <property name="source" ref="DYN_17_1460710398304DataSource" />
         <property name="appearance" ref="DYN_17_1460710398304Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5813,6 +6007,7 @@
         <property name="source" ref="DYN_18_1369735107391DataSource" />
         <property name="appearance" ref="DYN_18_1369735107391Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5826,6 +6021,7 @@
         <property name="source" ref="DYN_18_1370524532333DataSource" />
         <property name="appearance" ref="DYN_18_1370524532333Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5839,6 +6035,7 @@
         <property name="source" ref="DYN_18_1440594802970DataSource" />
         <property name="appearance" ref="DYN_18_1440594802970Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5852,6 +6049,7 @@
         <property name="source" ref="DYN_18_1440594848358DataSource" />
         <property name="appearance" ref="DYN_18_1440594848358Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5865,6 +6063,7 @@
         <property name="source" ref="DYN_18_1440594885950DataSource" />
         <property name="appearance" ref="DYN_18_1440594885950Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5878,6 +6077,7 @@
         <property name="source" ref="DYN_18_1440594891555DataSource" />
         <property name="appearance" ref="DYN_18_1440594891555Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5891,6 +6091,7 @@
         <property name="source" ref="DYN_83_1369390411276DataSource" />
         <property name="appearance" ref="DYN_83_1369390411276Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5904,6 +6105,7 @@
         <property name="source" ref="DYN_87_1370339367236DataSource" />
         <property name="appearance" ref="DYN_87_1370339367236Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5917,6 +6119,7 @@
         <property name="source" ref="DYN_89_1371032799773DataSource" />
         <property name="appearance" ref="DYN_89_1371032799773Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5930,6 +6133,7 @@
         <property name="source" ref="DYN_93_1370347899084DataSource" />
         <property name="appearance" ref="DYN_93_1370347899084Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5943,6 +6147,7 @@
         <property name="source" ref="DYN_93_1370614843635DataSource" />
         <property name="appearance" ref="DYN_93_1370614843635Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5956,6 +6161,7 @@
         <property name="source" ref="geopicsDataSource" />
         <property name="appearance" ref="geopicsAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5969,6 +6175,7 @@
         <property name="source" ref="ammoniumDataSource" />
         <property name="appearance" ref="ammoniumAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5982,6 +6189,7 @@
         <property name="source" ref="locations_masterDataSource" />
         <property name="appearance" ref="locations_masterAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -6000,7 +6208,7 @@
                 <ref bean="01_kharaa_river_basin_32648" />
                 <ref bean="01_kharaa_subbasins_32648" />
                 <ref bean="02_surface_water_bodies_32648" />
-                <ref bean="02_surface_water_bodies_corr_32648" />
+                <!-- <ref bean="02_surface_water_bodies_corr_32648" />
                 <ref bean="03_groundwater_bodies_32648" />
                 <ref bean="03_groundwater_monitoring_sites_32648" />
                 <ref bean="07_mining_operations_32648" />
@@ -6204,7 +6412,7 @@
                 <ref bean="locations_master" />
                 <ref bean="mongoliaStateCenters" />
                 <ref bean="osmTopo" />
-                <ref bean="osmWmsLayer" />
+                <ref bean="osmWmsLayer" />-->
                 <ref bean="osmWmsLayerGray" />
 
             </util:list>
@@ -6284,6 +6492,17 @@
         </property>
     </bean>
 
+    <bean id="hsiToolsModule" class="de.terrestris.shogun2.model.module.Button">
+        <property name="name" value="Activate hover-select tool" />
+        <property name="xtype" value="basigx-button-hsi" />
+        <property name="properties">
+             <util:map>
+                <entry key="scale" value="small" />
+                <entry key="ui" value="default" />
+             </util:map>
+        </property>
+    </bean>
+
     <bean id="showMeasureToolsModule" class="de.terrestris.shogun2.model.module.Button">
         <property name="name" value="Show measure tools button" />
         <property name="xtype" value="momo-button-showmeasuretoolspanel" />
@@ -6342,6 +6561,7 @@
                 <ref bean="zoomToExtentModule" />
                 <ref bean="stepBackModule" />
                 <ref bean="stepForwardModule" />
+                <ref bean="hsiToolsModule" />
                 <ref bean="showMeasureToolsModule" />
                 <ref bean="showRedliningToolsModule" />
             </util:list>

--- a/src/main/resources/META-INF/spring/dev/momo-context-initialize-beans.xml
+++ b/src/main/resources/META-INF/spring/dev/momo-context-initialize-beans.xml
@@ -7,7 +7,7 @@
                            http://www.springframework.org/schema/util
                            http://www.springframework.org/schema/util/spring-util.xsd">
 
-    <!--t
+    <!--
       The list of objects that shall be persisted.
 
       The order of the objects is important here (as one object may require

--- a/src/main/resources/META-INF/spring/prod/momo-context-initialize-beans.xml
+++ b/src/main/resources/META-INF/spring/prod/momo-context-initialize-beans.xml
@@ -7,7 +7,7 @@
                            http://www.springframework.org/schema/util
                            http://www.springframework.org/schema/util/spring-util.xsd">
 
-    <!--t
+    <!--
       The list of objects that shall be persisted.
 
       The order of the objects is important here (as one object may require
@@ -274,6 +274,7 @@
         <ref bean="zoomToExtentModule" />
         <ref bean="stepBackModule" />
         <ref bean="stepForwardModule" />
+        <ref bean="hsiToolsModule" />
         <ref bean="showMeasureToolsModule" />
         <ref bean="showRedliningToolsModule" />
 
@@ -3304,6 +3305,7 @@
         <property name="source" ref="mongoliaStateCentersDataSource" />
         <property name="appearance" ref="mongoliaStateCentersAppearance" />
         <property name="spatiallyRestricted" value="true" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3317,6 +3319,7 @@
         <property name="source" ref="osmTopoDataSource" />
         <property name="appearance" ref="osmTopoAppearance" />
         <property name="spatiallyRestricted" value="true" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3330,6 +3333,7 @@
         <property name="source" ref="01_kharaa_river_basin_32648DataSource" />
         <property name="appearance" ref="01_kharaa_river_basin_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3343,6 +3347,7 @@
         <property name="source" ref="01_kharaa_subbasins_32648DataSource" />
         <property name="appearance" ref="01_kharaa_subbasins_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3356,6 +3361,7 @@
         <property name="source" ref="02_surface_water_bodies_32648DataSource" />
         <property name="appearance" ref="02_surface_water_bodies_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3369,6 +3375,7 @@
         <property name="source" ref="02_surface_water_bodies_corr_32648DataSource" />
         <property name="appearance" ref="02_surface_water_bodies_corr_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3382,6 +3389,7 @@
         <property name="source" ref="03_groundwater_bodies_32648DataSource" />
         <property name="appearance" ref="03_groundwater_bodies_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3395,6 +3403,7 @@
         <property name="source" ref="03_groundwater_monitoring_sites_32648DataSource" />
         <property name="appearance" ref="03_groundwater_monitoring_sites_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3408,6 +3417,7 @@
         <property name="source" ref="07_mining_operations_32648DataSource" />
         <property name="appearance" ref="07_mining_operations_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3421,6 +3431,7 @@
         <property name="source" ref="07_potentially_contaminated_areas_32648DataSource" />
         <property name="appearance" ref="07_potentially_contaminated_areas_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3434,6 +3445,7 @@
         <property name="source" ref="07_risk_assessment_groundwater_bodies_32648DataSource" />
         <property name="appearance" ref="07_risk_assessment_groundwater_bodies_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3447,6 +3459,7 @@
         <property name="source" ref="07_risk_assessment_surface_water_bodies_32648DataSource" />
         <property name="appearance" ref="07_risk_assessment_surface_water_bodies_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3460,6 +3473,7 @@
         <property name="source" ref="2085_prec_sum_mngDataSource" />
         <property name="appearance" ref="2085_prec_sum_mngAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3473,6 +3487,7 @@
         <property name="source" ref="aet_1971-00DataSource" />
         <property name="appearance" ref="aet_1971-00Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3486,6 +3501,7 @@
         <property name="source" ref="aimag_boundaryDataSource" />
         <property name="appearance" ref="aimag_boundaryAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3499,6 +3515,7 @@
         <property name="source" ref="aimag_centerDataSource" />
         <property name="appearance" ref="aimag_centerAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3512,6 +3529,7 @@
         <property name="source" ref="aimagboundaryDataSource" />
         <property name="appearance" ref="aimagboundaryAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3525,6 +3543,7 @@
         <property name="source" ref="avail_1971-00DataSource" />
         <property name="appearance" ref="avail_1971-00Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3538,6 +3557,7 @@
         <property name="source" ref="avail_2011-40_a2_cncm3DataSource" />
         <property name="appearance" ref="avail_2011-40_a2_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3551,6 +3571,7 @@
         <property name="source" ref="avail_2011-40_a2_echam5DataSource" />
         <property name="appearance" ref="avail_2011-40_a2_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3564,6 +3585,7 @@
         <property name="source" ref="avail_2011-40_a2_ipslDataSource" />
         <property name="appearance" ref="avail_2011-40_a2_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3577,6 +3599,7 @@
         <property name="source" ref="avail_2011-40_b1_cncm3DataSource" />
         <property name="appearance" ref="avail_2011-40_b1_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3590,6 +3613,7 @@
         <property name="source" ref="avail_2011-40_b1_echam5DataSource" />
         <property name="appearance" ref="avail_2011-40_b1_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3603,6 +3627,7 @@
         <property name="source" ref="avail_2011-40_b1_ipslDataSource" />
         <property name="appearance" ref="avail_2011-40_b1_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3616,6 +3641,7 @@
         <property name="source" ref="avail_2041-70_a2_cncm3DataSource" />
         <property name="appearance" ref="avail_2041-70_a2_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3629,6 +3655,7 @@
         <property name="source" ref="avail_2041-70_a2_echam5DataSource" />
         <property name="appearance" ref="avail_2041-70_a2_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3642,6 +3669,7 @@
         <property name="source" ref="avail_2041-70_a2_ipslDataSource" />
         <property name="appearance" ref="avail_2041-70_a2_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3655,6 +3683,7 @@
         <property name="source" ref="avail_2041-70_b1_cncm3DataSource" />
         <property name="appearance" ref="avail_2041-70_b1_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3668,6 +3697,7 @@
         <property name="source" ref="avail_2041-70_b1_echam5DataSource" />
         <property name="appearance" ref="avail_2041-70_b1_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3681,6 +3711,7 @@
         <property name="source" ref="avail_2041-70_b1_ipslDataSource" />
         <property name="appearance" ref="avail_2041-70_b1_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3694,6 +3725,7 @@
         <property name="source" ref="avail_2071-00_a2_cncm3DataSource" />
         <property name="appearance" ref="avail_2071-00_a2_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3707,6 +3739,7 @@
         <property name="source" ref="avail_2071-00_a2_echam5DataSource" />
         <property name="appearance" ref="avail_2071-00_a2_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3720,6 +3753,7 @@
         <property name="source" ref="avail_2071-00_a2_ipslDataSource" />
         <property name="appearance" ref="avail_2071-00_a2_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3733,6 +3767,7 @@
         <property name="source" ref="avail_2071-00_b1_cncm3DataSource" />
         <property name="appearance" ref="avail_2071-00_b1_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3746,6 +3781,7 @@
         <property name="source" ref="avail_2071-00_b1_echam5DataSource" />
         <property name="appearance" ref="avail_2071-00_b1_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3759,6 +3795,7 @@
         <property name="source" ref="avail_2071-00_b1_ipslDataSource" />
         <property name="appearance" ref="avail_2071-00_b1_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3772,6 +3809,7 @@
         <property name="source" ref="big_riversDataSource" />
         <property name="appearance" ref="big_riversAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3785,6 +3823,7 @@
         <property name="source" ref="blue_marbleDataSource" />
         <property name="appearance" ref="blue_marbleAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3798,6 +3837,7 @@
         <property name="source" ref="buildingsDataSource" />
         <property name="appearance" ref="buildingsAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3811,6 +3851,7 @@
         <property name="source" ref="country_bordersDataSource" />
         <property name="appearance" ref="country_bordersAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3824,6 +3865,7 @@
         <property name="source" ref="cropland_1989_kharaaDataSource" />
         <property name="appearance" ref="cropland_1989_kharaaAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3837,6 +3879,7 @@
         <property name="source" ref="cropland_2006_kharaaDataSource" />
         <property name="appearance" ref="cropland_2006_kharaaAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3850,6 +3893,7 @@
         <property name="source" ref="DEM_30mDataSource" />
         <property name="appearance" ref="DEM_30mAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3863,6 +3907,7 @@
         <property name="source" ref="DEM_Mongolia_900mDataSource" />
         <property name="appearance" ref="DEM_Mongolia_900mAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3876,6 +3921,7 @@
         <property name="source" ref="digiriver_subbasinsDataSource" />
         <property name="appearance" ref="digiriver_subbasinsAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3889,6 +3935,7 @@
         <property name="source" ref="dyn_17_1369841595246DataSource" />
         <property name="appearance" ref="dyn_17_1369841595246Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3902,6 +3949,7 @@
         <property name="source" ref="ecological_status_kharaaDataSource" />
         <property name="appearance" ref="ecological_status_kharaaAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3915,6 +3963,7 @@
         <property name="source" ref="ecological_status_kharaa_uploadtestDataSource" />
         <property name="appearance" ref="ecological_status_kharaa_uploadtestAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3928,6 +3977,7 @@
         <property name="source" ref="einwohnerdichteDataSource" />
         <property name="appearance" ref="einwohnerdichteAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3941,6 +3991,7 @@
         <property name="source" ref="einwohnerdichte_darhanDataSource" />
         <property name="appearance" ref="einwohnerdichte_darhanAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3954,6 +4005,7 @@
         <property name="source" ref="gebaeudeDataSource" />
         <property name="appearance" ref="gebaeudeAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3967,6 +4019,7 @@
         <property name="source" ref="gebaeude_darkhan_32648_clipDataSource" />
         <property name="appearance" ref="gebaeude_darkhan_32648_clipAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3980,6 +4033,7 @@
         <property name="source" ref="gebaeude_darkhan_32648_clip_tryDataSource" />
         <property name="appearance" ref="gebaeude_darkhan_32648_clip_tryAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -3993,6 +4047,7 @@
         <property name="source" ref="gebaeude1_darhanDataSource" />
         <property name="appearance" ref="gebaeude1_darhanAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4006,6 +4061,7 @@
         <property name="source" ref="golDataSource" />
         <property name="appearance" ref="golAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4019,6 +4075,7 @@
         <property name="source" ref="kharaa_basinDataSource" />
         <property name="appearance" ref="kharaa_basinAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4032,6 +4089,7 @@
         <property name="source" ref="kharaa_darhanDataSource" />
         <property name="appearance" ref="kharaa_darhanAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4045,6 +4103,7 @@
         <property name="source" ref="kharaa_subbasinsDataSource" />
         <property name="appearance" ref="kharaa_subbasinsAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4058,6 +4117,7 @@
         <property name="source" ref="lakes_largeDataSource" />
         <property name="appearance" ref="lakes_largeAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4071,6 +4131,7 @@
         <property name="source" ref="landuseDataSource" />
         <property name="appearance" ref="landuseAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4084,6 +4145,7 @@
         <property name="source" ref="mng_roadsDataSource" />
         <property name="appearance" ref="mng_roadsAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4097,6 +4159,7 @@
         <property name="source" ref="naturalDataSource" />
         <property name="appearance" ref="naturalAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4110,6 +4173,7 @@
         <property name="source" ref="nuuruudDataSource" />
         <property name="appearance" ref="nuuruudAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4123,6 +4187,7 @@
         <property name="source" ref="ortho_drone_oczipkaDataSource" />
         <property name="appearance" ref="ortho_drone_oczipkaAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4136,6 +4201,7 @@
         <property name="source" ref="permafrostDataSource" />
         <property name="appearance" ref="permafrostAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4149,6 +4215,7 @@
         <property name="source" ref="phenomenonzonemetaDataSource" />
         <property name="appearance" ref="phenomenonzonemetaAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4162,6 +4229,7 @@
         <property name="source" ref="placesDataSource" />
         <property name="appearance" ref="placesAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4175,6 +4243,7 @@
         <property name="source" ref="pointsDataSource" />
         <property name="appearance" ref="pointsAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4188,6 +4257,7 @@
         <property name="source" ref="populationdensity_darhanDataSource" />
         <property name="appearance" ref="populationdensity_darhanAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4201,6 +4271,7 @@
         <property name="source" ref="precip_1971-00DataSource" />
         <property name="appearance" ref="precip_1971-00Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4214,6 +4285,7 @@
         <property name="source" ref="precip_2011-40_a2_cncm3DataSource" />
         <property name="appearance" ref="precip_2011-40_a2_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4227,6 +4299,7 @@
         <property name="source" ref="precip_2011-40_a2_echam5DataSource" />
         <property name="appearance" ref="precip_2011-40_a2_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4240,6 +4313,7 @@
         <property name="source" ref="precip_2011-40_a2_ipslDataSource" />
         <property name="appearance" ref="precip_2011-40_a2_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4253,6 +4327,7 @@
         <property name="source" ref="precip_2011-40_b1_cncm3DataSource" />
         <property name="appearance" ref="precip_2011-40_b1_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4266,6 +4341,7 @@
         <property name="source" ref="precip_2011-40_b1_echam5DataSource" />
         <property name="appearance" ref="precip_2011-40_b1_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4279,6 +4355,7 @@
         <property name="source" ref="precip_2011-40_b1_ipslDataSource" />
         <property name="appearance" ref="precip_2011-40_b1_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4292,6 +4369,7 @@
         <property name="source" ref="precip_2041-70_a2_cncm3DataSource" />
         <property name="appearance" ref="precip_2041-70_a2_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4305,6 +4383,7 @@
         <property name="source" ref="precip_2041-70_a2_echam5DataSource" />
         <property name="appearance" ref="precip_2041-70_a2_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4318,6 +4397,7 @@
         <property name="source" ref="precip_2041-70_a2_ipslDataSource" />
         <property name="appearance" ref="precip_2041-70_a2_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4331,6 +4411,7 @@
         <property name="source" ref="precip_2041-70_b1_cncm3DataSource" />
         <property name="appearance" ref="precip_2041-70_b1_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4344,6 +4425,7 @@
         <property name="source" ref="precip_2041-70_b1_echam5DataSource" />
         <property name="appearance" ref="precip_2041-70_b1_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4357,6 +4439,7 @@
         <property name="source" ref="precip_2041-70_b1_ipslDataSource" />
         <property name="appearance" ref="precip_2041-70_b1_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4370,6 +4453,7 @@
         <property name="source" ref="precip_2071-00_a2_cncm3DataSource" />
         <property name="appearance" ref="precip_2071-00_a2_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4383,6 +4467,7 @@
         <property name="source" ref="precip_2071-00_a2_echam5DataSource" />
         <property name="appearance" ref="precip_2071-00_a2_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4396,6 +4481,7 @@
         <property name="source" ref="precip_2071-00_a2_ipslDataSource" />
         <property name="appearance" ref="precip_2071-00_a2_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4409,6 +4495,7 @@
         <property name="source" ref="precip_2071-00_b1_cncm3DataSource" />
         <property name="appearance" ref="precip_2071-00_b1_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4422,6 +4509,7 @@
         <property name="source" ref="precip_2071-00_b1_echam5DataSource" />
         <property name="appearance" ref="precip_2071-00_b1_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4435,6 +4523,7 @@
         <property name="source" ref="precip_2071-00_b1_ipslDataSource" />
         <property name="appearance" ref="precip_2071-00_b1_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4448,6 +4537,7 @@
         <property name="source" ref="protected_areasDataSource" />
         <property name="appearance" ref="protected_areasAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4461,6 +4551,7 @@
         <property name="source" ref="rail_roadDataSource" />
         <property name="appearance" ref="rail_roadAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4474,6 +4565,7 @@
         <property name="source" ref="railwaysDataSource" />
         <property name="appearance" ref="railwaysAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4487,6 +4579,7 @@
         <property name="source" ref="roadsDataSource" />
         <property name="appearance" ref="roadsAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4500,6 +4593,7 @@
         <property name="source" ref="snow_cover_fraction_1971-00DataSource" />
         <property name="appearance" ref="snow_cover_fraction_1971-00Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4513,6 +4607,7 @@
         <property name="source" ref="soum_center342DataSource" />
         <property name="appearance" ref="soum_center342Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4526,6 +4621,7 @@
         <property name="source" ref="state_boundaryDataSource" />
         <property name="appearance" ref="state_boundaryAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4539,6 +4635,7 @@
         <property name="source" ref="temp_1971-00DataSource" />
         <property name="appearance" ref="temp_1971-00Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4552,6 +4649,7 @@
         <property name="source" ref="temp_2011-40_a2_cncm3DataSource" />
         <property name="appearance" ref="temp_2011-40_a2_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4565,6 +4663,7 @@
         <property name="source" ref="temp_2011-40_a2_echam5DataSource" />
         <property name="appearance" ref="temp_2011-40_a2_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4578,6 +4677,7 @@
         <property name="source" ref="temp_2011-40_a2_ipslDataSource" />
         <property name="appearance" ref="temp_2011-40_a2_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4591,6 +4691,7 @@
         <property name="source" ref="temp_2011-40_b1_cncm3DataSource" />
         <property name="appearance" ref="temp_2011-40_b1_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4604,6 +4705,7 @@
         <property name="source" ref="temp_2011-40_b1_echam5DataSource" />
         <property name="appearance" ref="temp_2011-40_b1_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4617,6 +4719,7 @@
         <property name="source" ref="temp_2011-40_b1_ipslDataSource" />
         <property name="appearance" ref="temp_2011-40_b1_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4630,6 +4733,7 @@
         <property name="source" ref="temp_2041-70_a2_cncm3DataSource" />
         <property name="appearance" ref="temp_2041-70_a2_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4643,6 +4747,7 @@
         <property name="source" ref="temp_2041-70_a2_echam5DataSource" />
         <property name="appearance" ref="temp_2041-70_a2_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4656,6 +4761,7 @@
         <property name="source" ref="temp_2041-70_a2_ipslDataSource" />
         <property name="appearance" ref="temp_2041-70_a2_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4669,6 +4775,7 @@
         <property name="source" ref="temp_2041-70_b1_cncm3DataSource" />
         <property name="appearance" ref="temp_2041-70_b1_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4682,6 +4789,7 @@
         <property name="source" ref="temp_2041-70_b1_echam5DataSource" />
         <property name="appearance" ref="temp_2041-70_b1_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4695,6 +4803,7 @@
         <property name="source" ref="temp_2041-70_b1_ipslDataSource" />
         <property name="appearance" ref="temp_2041-70_b1_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4708,6 +4817,7 @@
         <property name="source" ref="temp_2071-00_a2_cncm3DataSource" />
         <property name="appearance" ref="temp_2071-00_a2_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4721,6 +4831,7 @@
         <property name="source" ref="temp_2071-00_a2_echam5DataSource" />
         <property name="appearance" ref="temp_2071-00_a2_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4734,6 +4845,7 @@
         <property name="source" ref="temp_2071-00_a2_ipslDataSource" />
         <property name="appearance" ref="temp_2071-00_a2_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4747,6 +4859,7 @@
         <property name="source" ref="temp_2071-00_b1_cncm3DataSource" />
         <property name="appearance" ref="temp_2071-00_b1_cncm3Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4760,6 +4873,7 @@
         <property name="source" ref="temp_2071-00_b1_echam5DataSource" />
         <property name="appearance" ref="temp_2071-00_b1_echam5Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4773,6 +4887,7 @@
         <property name="source" ref="temp_2071-00_b1_ipslDataSource" />
         <property name="appearance" ref="temp_2071-00_b1_ipslAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4786,6 +4901,7 @@
         <property name="source" ref="TM5_2010DataSource" />
         <property name="appearance" ref="TM5_2010Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4799,6 +4915,7 @@
         <property name="source" ref="wasserkioske_bag7_32648DataSource" />
         <property name="appearance" ref="wasserkioske_bag7_32648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4812,6 +4929,7 @@
         <property name="source" ref="wastewater_darhanDataSource" />
         <property name="appearance" ref="wastewater_darhanAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4825,6 +4943,7 @@
         <property name="source" ref="waterwaysDataSource" />
         <property name="appearance" ref="waterwaysAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4838,6 +4957,7 @@
         <property name="source" ref="wg3_webgis_cruDataSource" />
         <property name="appearance" ref="wg3_webgis_cruAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4851,6 +4971,7 @@
         <property name="source" ref="DYN_109_1369735105591DataSource" />
         <property name="appearance" ref="DYN_109_1369735105591Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4864,6 +4985,7 @@
         <property name="source" ref="DYN_109_1369742468725DataSource" />
         <property name="appearance" ref="DYN_109_1369742468725Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4877,6 +4999,7 @@
         <property name="source" ref="DYN_109_1369841716922DataSource" />
         <property name="appearance" ref="DYN_109_1369841716922Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4890,6 +5013,7 @@
         <property name="source" ref="DYN_13_1365601378477DataSource" />
         <property name="appearance" ref="DYN_13_1365601378477Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4903,6 +5027,7 @@
         <property name="source" ref="DYN_13_1365601542355DataSource" />
         <property name="appearance" ref="DYN_13_1365601542355Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4916,6 +5041,7 @@
         <property name="source" ref="DYN_14_1365602120228DataSource" />
         <property name="appearance" ref="DYN_14_1365602120228Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4929,6 +5055,7 @@
         <property name="source" ref="DYN_14_1365605442839DataSource" />
         <property name="appearance" ref="DYN_14_1365605442839Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4942,6 +5069,7 @@
         <property name="source" ref="DYN_14_1365605456216DataSource" />
         <property name="appearance" ref="DYN_14_1365605456216Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4955,6 +5083,7 @@
         <property name="source" ref="DYN_14_1365605476506DataSource" />
         <property name="appearance" ref="DYN_14_1365605476506Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4968,6 +5097,7 @@
         <property name="source" ref="DYN_14_1365605781970DataSource" />
         <property name="appearance" ref="DYN_14_1365605781970Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4981,6 +5111,7 @@
         <property name="source" ref="DYN_14_1365605882959DataSource" />
         <property name="appearance" ref="DYN_14_1365605882959Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -4994,6 +5125,7 @@
         <property name="source" ref="DYN_14_1365605890897DataSource" />
         <property name="appearance" ref="DYN_14_1365605890897Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5007,6 +5139,7 @@
         <property name="source" ref="DYN_14_1365605955459DataSource" />
         <property name="appearance" ref="DYN_14_1365605955459Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5020,6 +5153,7 @@
         <property name="source" ref="DYN_14_1365605978459DataSource" />
         <property name="appearance" ref="DYN_14_1365605978459Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5033,6 +5167,7 @@
         <property name="source" ref="DYN_14_1365605987568DataSource" />
         <property name="appearance" ref="DYN_14_1365605987568Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5046,6 +5181,7 @@
         <property name="source" ref="DYN_14_1365605992016DataSource" />
         <property name="appearance" ref="DYN_14_1365605992016Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5059,6 +5195,7 @@
         <property name="source" ref="DYN_14_1365605995942DataSource" />
         <property name="appearance" ref="DYN_14_1365605995942Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5072,6 +5209,7 @@
         <property name="source" ref="DYN_14_1365608956030DataSource" />
         <property name="appearance" ref="DYN_14_1365608956030Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5085,6 +5223,7 @@
         <property name="source" ref="DYN_14_1365694916518DataSource" />
         <property name="appearance" ref="DYN_14_1365694916518Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5098,6 +5237,7 @@
         <property name="source" ref="DYN_14_1365759012080DataSource" />
         <property name="appearance" ref="DYN_14_1365759012080Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5111,6 +5251,7 @@
         <property name="source" ref="DYN_14_1365759879641DataSource" />
         <property name="appearance" ref="DYN_14_1365759879641Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5124,6 +5265,7 @@
         <property name="source" ref="DYN_14_1365760699624DataSource" />
         <property name="appearance" ref="DYN_14_1365760699624Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5137,6 +5279,7 @@
         <property name="source" ref="DYN_14_1365761490659DataSource" />
         <property name="appearance" ref="DYN_14_1365761490659Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5150,6 +5293,7 @@
         <property name="source" ref="DYN_14_1365761504280DataSource" />
         <property name="appearance" ref="DYN_14_1365761504280Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5163,6 +5307,7 @@
         <property name="source" ref="DYN_14_1366635679454DataSource" />
         <property name="appearance" ref="DYN_14_1366635679454Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5176,6 +5321,7 @@
         <property name="source" ref="DYN_14_1366635904632DataSource" />
         <property name="appearance" ref="DYN_14_1366635904632Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5189,6 +5335,7 @@
         <property name="source" ref="DYN_14_1366704342968DataSource" />
         <property name="appearance" ref="DYN_14_1366704342968Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5202,6 +5349,7 @@
         <property name="source" ref="DYN_14_1367228008564DataSource" />
         <property name="appearance" ref="DYN_14_1367228008564Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5215,6 +5363,7 @@
         <property name="source" ref="DYN_14_1367848456001DataSource" />
         <property name="appearance" ref="DYN_14_1367848456001Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5228,6 +5377,7 @@
         <property name="source" ref="DYN_14_1367938733533DataSource" />
         <property name="appearance" ref="DYN_14_1367938733533Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5241,6 +5391,7 @@
         <property name="source" ref="DYN_14_1368001502620DataSource" />
         <property name="appearance" ref="DYN_14_1368001502620Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5254,6 +5405,7 @@
         <property name="source" ref="DYN_14_1368001531956DataSource" />
         <property name="appearance" ref="DYN_14_1368001531956Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5267,6 +5419,7 @@
         <property name="source" ref="DYN_14_1368431465466DataSource" />
         <property name="appearance" ref="DYN_14_1368431465466Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5280,6 +5433,7 @@
         <property name="source" ref="DYN_14_1369216335515DataSource" />
         <property name="appearance" ref="DYN_14_1369216335515Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5293,6 +5447,7 @@
         <property name="source" ref="DYN_14_1369390350022DataSource" />
         <property name="appearance" ref="DYN_14_1369390350022Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5306,6 +5461,7 @@
         <property name="source" ref="DYN_14_1369657232648DataSource" />
         <property name="appearance" ref="DYN_14_1369657232648Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5319,6 +5475,7 @@
         <property name="source" ref="DYN_15_1365608726707DataSource" />
         <property name="appearance" ref="DYN_15_1365608726707Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5332,6 +5489,7 @@
         <property name="source" ref="DYN_15_1365608732880DataSource" />
         <property name="appearance" ref="DYN_15_1365608732880Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5345,6 +5503,7 @@
         <property name="source" ref="DYN_15_1365608753118DataSource" />
         <property name="appearance" ref="DYN_15_1365608753118Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5358,6 +5517,7 @@
         <property name="source" ref="DYN_15_1365608802067DataSource" />
         <property name="appearance" ref="DYN_15_1365608802067Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5371,6 +5531,7 @@
         <property name="source" ref="DYN_15_1365608806430DataSource" />
         <property name="appearance" ref="DYN_15_1365608806430Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5384,6 +5545,7 @@
         <property name="source" ref="DYN_15_1365610632020DataSource" />
         <property name="appearance" ref="DYN_15_1365610632020Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5397,6 +5559,7 @@
         <property name="source" ref="DYN_17_1369658293805DataSource" />
         <property name="appearance" ref="DYN_17_1369658293805Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5410,6 +5573,7 @@
         <property name="source" ref="DYN_17_1369661200358DataSource" />
         <property name="appearance" ref="DYN_17_1369661200358Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5423,6 +5587,7 @@
         <property name="source" ref="DYN_17_1369663868865DataSource" />
         <property name="appearance" ref="DYN_17_1369663868865Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5436,6 +5601,7 @@
         <property name="source" ref="DYN_17_1369664218638DataSource" />
         <property name="appearance" ref="DYN_17_1369664218638Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5449,6 +5615,7 @@
         <property name="source" ref="DYN_17_1369664356511DataSource" />
         <property name="appearance" ref="DYN_17_1369664356511Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5462,6 +5629,7 @@
         <property name="source" ref="DYN_17_1369727728084DataSource" />
         <property name="appearance" ref="DYN_17_1369727728084Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5475,6 +5643,7 @@
         <property name="source" ref="DYN_17_1369841595246DataSource" />
         <property name="appearance" ref="DYN_17_1369841595246Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5488,6 +5657,7 @@
         <property name="source" ref="DYN_17_1370248326413DataSource" />
         <property name="appearance" ref="DYN_17_1370248326413Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5501,6 +5671,7 @@
         <property name="source" ref="DYN_17_1370268433786DataSource" />
         <property name="appearance" ref="DYN_17_1370268433786Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5514,6 +5685,7 @@
         <property name="source" ref="DYN_17_1370331977802DataSource" />
         <property name="appearance" ref="DYN_17_1370331977802Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5527,6 +5699,7 @@
         <property name="source" ref="DYN_17_1370339370321DataSource" />
         <property name="appearance" ref="DYN_17_1370339370321Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5540,6 +5713,7 @@
         <property name="source" ref="DYN_17_1370346706787DataSource" />
         <property name="appearance" ref="DYN_17_1370346706787Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5553,6 +5727,7 @@
         <property name="source" ref="DYN_17_1370347864927DataSource" />
         <property name="appearance" ref="DYN_17_1370347864927Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5566,6 +5741,7 @@
         <property name="source" ref="DYN_17_1370358118751DataSource" />
         <property name="appearance" ref="DYN_17_1370358118751Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5579,6 +5755,7 @@
         <property name="source" ref="DYN_17_1370437834297DataSource" />
         <property name="appearance" ref="DYN_17_1370437834297Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5592,6 +5769,7 @@
         <property name="source" ref="DYN_17_1370522051248DataSource" />
         <property name="appearance" ref="DYN_17_1370522051248Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5605,6 +5783,7 @@
         <property name="source" ref="DYN_17_1370524783155DataSource" />
         <property name="appearance" ref="DYN_17_1370524783155Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5618,6 +5797,7 @@
         <property name="source" ref="DYN_17_1370616707097DataSource" />
         <property name="appearance" ref="DYN_17_1370616707097Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5631,6 +5811,7 @@
         <property name="source" ref="DYN_17_1370616707230DataSource" />
         <property name="appearance" ref="DYN_17_1370616707230Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5644,6 +5825,7 @@
         <property name="source" ref="DYN_17_1371032794782DataSource" />
         <property name="appearance" ref="DYN_17_1371032794782Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5657,6 +5839,7 @@
         <property name="source" ref="DYN_17_1371145490632DataSource" />
         <property name="appearance" ref="DYN_17_1371145490632Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5670,6 +5853,7 @@
         <property name="source" ref="DYN_17_1375109485576DataSource" />
         <property name="appearance" ref="DYN_17_1375109485576Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5683,6 +5867,7 @@
         <property name="source" ref="DYN_17_1377852947018DataSource" />
         <property name="appearance" ref="DYN_17_1377852947018Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5696,6 +5881,7 @@
         <property name="source" ref="DYN_17_1441115410183DataSource" />
         <property name="appearance" ref="DYN_17_1441115410183Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5709,6 +5895,7 @@
         <property name="source" ref="DYN_17_1441204749960DataSource" />
         <property name="appearance" ref="DYN_17_1441204749960Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5722,6 +5909,7 @@
         <property name="source" ref="DYN_17_1441206453307DataSource" />
         <property name="appearance" ref="DYN_17_1441206453307Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5735,6 +5923,7 @@
         <property name="source" ref="DYN_17_1441291537965DataSource" />
         <property name="appearance" ref="DYN_17_1441291537965Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5748,6 +5937,7 @@
         <property name="source" ref="DYN_17_1441765273807DataSource" />
         <property name="appearance" ref="DYN_17_1441765273807Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5761,6 +5951,7 @@
         <property name="source" ref="DYN_17_1448369691146DataSource" />
         <property name="appearance" ref="DYN_17_1448369691146Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5774,6 +5965,7 @@
         <property name="source" ref="DYN_17_1452004915902DataSource" />
         <property name="appearance" ref="DYN_17_1452004915902Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5787,6 +5979,7 @@
         <property name="source" ref="DYN_17_1456828579111DataSource" />
         <property name="appearance" ref="DYN_17_1456828579111Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5800,6 +5993,7 @@
         <property name="source" ref="DYN_17_1460710398304DataSource" />
         <property name="appearance" ref="DYN_17_1460710398304Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5813,6 +6007,7 @@
         <property name="source" ref="DYN_18_1369735107391DataSource" />
         <property name="appearance" ref="DYN_18_1369735107391Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5826,6 +6021,7 @@
         <property name="source" ref="DYN_18_1370524532333DataSource" />
         <property name="appearance" ref="DYN_18_1370524532333Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5839,6 +6035,7 @@
         <property name="source" ref="DYN_18_1440594802970DataSource" />
         <property name="appearance" ref="DYN_18_1440594802970Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5852,6 +6049,7 @@
         <property name="source" ref="DYN_18_1440594848358DataSource" />
         <property name="appearance" ref="DYN_18_1440594848358Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5865,6 +6063,7 @@
         <property name="source" ref="DYN_18_1440594885950DataSource" />
         <property name="appearance" ref="DYN_18_1440594885950Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5878,6 +6077,7 @@
         <property name="source" ref="DYN_18_1440594891555DataSource" />
         <property name="appearance" ref="DYN_18_1440594891555Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5891,6 +6091,7 @@
         <property name="source" ref="DYN_83_1369390411276DataSource" />
         <property name="appearance" ref="DYN_83_1369390411276Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5904,6 +6105,7 @@
         <property name="source" ref="DYN_87_1370339367236DataSource" />
         <property name="appearance" ref="DYN_87_1370339367236Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5917,6 +6119,7 @@
         <property name="source" ref="DYN_89_1371032799773DataSource" />
         <property name="appearance" ref="DYN_89_1371032799773Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5930,6 +6133,7 @@
         <property name="source" ref="DYN_93_1370347899084DataSource" />
         <property name="appearance" ref="DYN_93_1370347899084Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5943,6 +6147,7 @@
         <property name="source" ref="DYN_93_1370614843635DataSource" />
         <property name="appearance" ref="DYN_93_1370614843635Appearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5956,6 +6161,7 @@
         <property name="source" ref="geopicsDataSource" />
         <property name="appearance" ref="geopicsAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5969,6 +6175,7 @@
         <property name="source" ref="ammoniumDataSource" />
         <property name="appearance" ref="ammoniumAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -5982,6 +6189,7 @@
         <property name="source" ref="locations_masterDataSource" />
         <property name="appearance" ref="locations_masterAppearance" />
         <property name="spatiallyRestricted" value="false" />
+        <property name="hoverable" value="true" />
         <property name="userPermissions">
             <!-- Allow that the default user to READ this application -->
             <util:map>
@@ -6000,7 +6208,7 @@
                 <ref bean="01_kharaa_river_basin_32648" />
                 <ref bean="01_kharaa_subbasins_32648" />
                 <ref bean="02_surface_water_bodies_32648" />
-                <ref bean="02_surface_water_bodies_corr_32648" />
+                <!-- <ref bean="02_surface_water_bodies_corr_32648" />
                 <ref bean="03_groundwater_bodies_32648" />
                 <ref bean="03_groundwater_monitoring_sites_32648" />
                 <ref bean="07_mining_operations_32648" />
@@ -6204,7 +6412,7 @@
                 <ref bean="locations_master" />
                 <ref bean="mongoliaStateCenters" />
                 <ref bean="osmTopo" />
-                <ref bean="osmWmsLayer" />
+                <ref bean="osmWmsLayer" />-->
                 <ref bean="osmWmsLayerGray" />
 
             </util:list>
@@ -6284,6 +6492,17 @@
         </property>
     </bean>
 
+    <bean id="hsiToolsModule" class="de.terrestris.shogun2.model.module.Button">
+        <property name="name" value="Activate hover-select tool" />
+        <property name="xtype" value="basigx-button-hsi" />
+        <property name="properties">
+             <util:map>
+                <entry key="scale" value="small" />
+                <entry key="ui" value="default" />
+             </util:map>
+        </property>
+    </bean>
+
     <bean id="showMeasureToolsModule" class="de.terrestris.shogun2.model.module.Button">
         <property name="name" value="Show measure tools button" />
         <property name="xtype" value="momo-button-showmeasuretoolspanel" />
@@ -6342,6 +6561,7 @@
                 <ref bean="zoomToExtentModule" />
                 <ref bean="stepBackModule" />
                 <ref bean="stepForwardModule" />
+                <ref bean="hsiToolsModule" />
                 <ref bean="showMeasureToolsModule" />
                 <ref bean="showRedliningToolsModule" />
             </util:list>


### PR DESCRIPTION
This PR provides the following changes:
-  A new bean for `hsiToolsModule` was introduced
- Interceptor responce for `GetFeatureInfo` are allowed now
- New property `hoverable` was added to the momo layer model to determine the queryable layers in frontend
- `Proj4` library was added via gitmodules since the most of momo layers are in "not native" projection `EPSG:32648`

Corresponding PR in frontend: https://github.com/terrestris/momo3-frontend/pull/32

Please review @buehner @marcjansen 
