### PR TITLE
Print module

### DIFF
--- a/src/main/java/de/terrestris/momo/interceptor/MomoWmsRequestInterceptor.java
+++ b/src/main/java/de/terrestris/momo/interceptor/MomoWmsRequestInterceptor.java
@@ -68,7 +68,7 @@ public class MomoWmsRequestInterceptor implements WmsRequestInterceptorInterface
 	/**
 	 *
 	 */
-	@Value("${shogun2.geoserverInterceptorUrl}")
+	@Value("${momo.publicInterceptGeoServerAction}")
 	private String geoserverInterceptorUrl;
 
 	/**

--- a/src/main/java/de/terrestris/momo/service/PrintService.java
+++ b/src/main/java/de/terrestris/momo/service/PrintService.java
@@ -1,0 +1,150 @@
+package de.terrestris.momo.service;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+import de.terrestris.shogun2.util.http.HttpUtil;
+import de.terrestris.shogun2.util.model.Response;
+
+/**
+*
+* @author Johannes Weskamm
+* @author terrestris GmbH & Co. KG
+*
+*/
+@Service("printService")
+public class PrintService {
+
+	/**
+	 *
+	 */
+	@Autowired
+	@Qualifier("printservletBaseUrl")
+	private String printservletBaseUrl;
+
+	/**
+	 *
+	 */
+	@Autowired
+	@Qualifier("geoServerBaseUrl")
+	private String geoServerBaseUrl;
+
+	/**
+	 *
+	 */
+	@Autowired
+	@Qualifier("publicInterceptGeoServerAction")
+	private String publicInterceptGeoServerAction;
+
+	/**
+	 * The Logger
+	 */
+	private static final Logger LOG =
+			Logger.getLogger(PrintService.class);
+
+	/**
+	 * intercept the print payload, replace relative interceptor urls
+	 * with absolute urls
+	 *
+	 * @param printSpec
+	 * @param request
+	 * @param printApp
+	 * @param format
+	 * @return
+	 */
+	public Response interceptPrint(String printSpec, HttpServletRequest request, String printApp,
+			String format) {
+		Response response = null;
+		try {
+
+			ObjectMapper mapper = new ObjectMapper();
+			JsonNode jsonTree = mapper.readTree(printSpec);
+
+			JsonNode replacedTree = replaceInterceptorUrlsInJson(jsonTree);
+			replacedTree = removeCustomVersionParam(jsonTree);
+
+			List<NameValuePair> queryParams = new ArrayList<NameValuePair>(1);
+			queryParams.add(new BasicNameValuePair("spec",replacedTree.toString()));
+			String url = printservletBaseUrl + "print/" + printApp + "/buildreport." + format;
+			response = HttpUtil.post(url, queryParams);
+		} catch (Exception e) {
+			LOG.error("Error on intercepting a print request: " + e.getMessage(), e);
+		}
+		return response;
+	}
+
+	/**
+	 * Method recursively searches for a relative interceptor url and
+	 * replaces it with the geoserver base url
+	 *
+	 * @param jsonNode
+	 * @return
+	 */
+	private JsonNode replaceInterceptorUrlsInJson(JsonNode jsonNode) {
+
+		if (jsonNode.isArray()) {
+			Iterator<JsonNode> elements = jsonNode.elements();
+			while (elements.hasNext()) {
+				replaceInterceptorUrlsInJson(elements.next());
+			}
+		} else if (jsonNode.isObject()) {
+			Iterator<String> fieldNames = jsonNode.fieldNames();
+			while (fieldNames.hasNext()) {
+				String fieldName = fieldNames.next();
+				JsonNode childNode = jsonNode.get(fieldName);
+				JsonNode newJsonNode = replaceInterceptorUrlsInJson(childNode);
+
+				if(!childNode.equals(newJsonNode)) {
+					((ObjectNode)jsonNode).replace(fieldName, newJsonNode);
+				}
+
+			}
+		} else if (jsonNode.isTextual()) {
+			String value = jsonNode.asText();
+			if (value.contains(publicInterceptGeoServerAction)) {
+				String replacedString = value.replace(
+						publicInterceptGeoServerAction, geoServerBaseUrl);
+				jsonNode = new TextNode(replacedString);
+			}
+		}
+		return jsonNode;
+	}
+
+	/**
+	 * Method removes the VERSION parameter from a layers customParams,
+	 * as this breaks the printservlet, which assumes a verison per default
+	 *
+	 * @param jsonTree
+	 * @return
+	 */
+	private JsonNode removeCustomVersionParam(JsonNode jsonTree) {
+		List<JsonNode> customParamsNodes = jsonTree.findValues("customParams");
+		for (JsonNode customParamsNode : customParamsNodes) {
+			if (customParamsNode != null) {
+				JsonNode versionNode = customParamsNode.findValue("VERSION");
+				if (versionNode != null) {
+					JsonNode value = ((ObjectNode)customParamsNode).remove("VERSION");
+					if (value != null) {
+						LOG.debug("Removed an uneccessary VERSION parameter in customParams");
+					}
+				}
+			}
+		}
+		return jsonTree;
+	}
+}

--- a/src/main/java/de/terrestris/momo/web/PrintController.java
+++ b/src/main/java/de/terrestris/momo/web/PrintController.java
@@ -1,0 +1,123 @@
+/**
+ *
+ */
+package de.terrestris.momo.web;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import de.terrestris.momo.service.PrintService;
+import de.terrestris.shogun2.util.http.HttpUtil;
+import de.terrestris.shogun2.util.model.Response;
+
+/**
+ * @author Johannes Weskamm
+ *
+ */
+@Controller
+@RequestMapping("/print")
+public class PrintController {
+
+	/**
+	 *
+	 */
+	@Autowired
+	@Qualifier("printservletBaseUrl")
+	private String printservletBaseUrl;
+
+	/**
+	 * The Logger
+	 */
+	private static final Logger LOG = Logger.getLogger(PrintController.class);
+
+	@Autowired
+	@Qualifier("printService")
+	private PrintService service;
+
+	/**
+	 * Forwarding the apps.json request
+	 *
+	 * @param jsonp
+	 * @return
+	 */
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@RequestMapping(value = "/print/apps.json", method = RequestMethod.GET)
+	public @ResponseBody ResponseEntity<byte[]> getApps(@RequestParam("jsonp") String jsonp) {
+		LOG.debug("Requested to intercept a print 'apps' request");
+		String url = printservletBaseUrl + "print/apps.json?jsonp=" + jsonp;
+		try {
+			Response response = HttpUtil.get(url);
+			return new ResponseEntity(response.getBody(), response.getHeaders(), response.getStatusCode());
+		} catch (Exception e) {
+			LOG.error("Error intercepting a print 'apps' request: ", e);
+			HttpHeaders headers = new HttpHeaders();
+			headers.setContentType(MediaType.APPLICATION_JSON);
+			return new ResponseEntity("", headers, HttpStatus.NOT_FOUND);
+		}
+	}
+
+	/**
+	 * Forwarding the capabilities.json request
+	 *
+	 * @param jsonp
+	 * @return
+	 */
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@RequestMapping(value = "/print/{printApp}/capabilities.json", method = RequestMethod.GET)
+	public @ResponseBody ResponseEntity<byte[]> getCapabilities(@RequestParam("jsonp") String jsonp,
+			@PathVariable("printApp") String printApp) {
+		LOG.debug("Requested to intercept a print 'capabilities' request");
+
+		String url = printservletBaseUrl + "print/" + printApp + "/capabilities.json?jsonp=" + jsonp;
+		try {
+			Response response = HttpUtil.get(url);
+			return new ResponseEntity(response.getBody(), response.getHeaders(), response.getStatusCode());
+		} catch (Exception e) {
+			LOG.error("Error intercepting a print 'capabilities' request: ", e);
+			HttpHeaders headers = new HttpHeaders();
+			headers.setContentType(MediaType.APPLICATION_JSON);
+			return new ResponseEntity("", headers, HttpStatus.NOT_FOUND);
+		}
+	}
+
+	/**
+	 * Forwarding the buildreport.pdf request, intercepting payload to replace
+	 * interceptor urls with absolute urls
+	 *
+	 * @param printSpec
+	 * @param request
+	 * @param printApp
+	 * @return
+	 */
+	@RequestMapping(value = "/print/{printApp}/buildreport.{format}", method = {RequestMethod.GET, RequestMethod.POST})
+	public @ResponseBody ResponseEntity<byte[]> intercept(@RequestParam("spec") String printSpec,
+			HttpServletRequest request, @PathVariable("printApp") String printApp,
+			@PathVariable("format") String format) {
+		LOG.debug("Requested to intercept a print 'buildreport' request");
+
+		try {
+			Response response = service.interceptPrint(printSpec, request, printApp, format);
+			return new ResponseEntity<byte[]>(response.getBody(), response.getHeaders(), response.getStatusCode());
+		} catch (Exception e) {
+			LOG.error("Error intercepting a print 'buildreport' request: ", e);
+			HttpHeaders headers = new HttpHeaders();
+			headers.setContentType(MediaType.APPLICATION_JSON);
+			return new ResponseEntity<byte[]>(new byte[0], headers, HttpStatus.NOT_FOUND);
+		}
+	}
+
+}
+

--- a/src/main/resources/META-INF/config/ci/momo.properties
+++ b/src/main/resources/META-INF/config/ci/momo.properties
@@ -6,7 +6,14 @@
 http.timeout=30000
 
 # The URL of the geoserver interceptor in this project
-shogun2.geoserverInterceptorUrl=/momo/geoserver.action
+momo.publicInterceptGeoServerAction=/momo/geoserver.action
+
+# GeoServer BaseUrl
+geoserver.baseUrl=http://188.40.113.28/geoserver/momo/ows/
+
+# PrintServlet BaseUrl and interceptor
+printservlet.baseUrl=http://188.40.113.28/print-servlet-3.6.0/
+printservlet.interceptorUrl=/momo/print
 
 # The name of the SUPERADMIN role
 # (a user with this role is allowed to do everything)
@@ -16,10 +23,10 @@ role.superAdminRoleName=ROLE_ADMIN
 role.defaultUserRoleName=ROLE_USER
 
 # The name of the feature type that is used to mask/restrict GetMap requests
-momo.maskingFeatureType=momo:Aimag_boundary
+momo.maskingFeatureType=momo:aimag_boundary
 
 # The name of the property of the maskingFeatureType from above that is used to mask/restrict GetMap requests
-momo.maskingPropertyName=Aimag_ID
+momo.maskingPropertyName=aimag_id
 
 # The name of the SLD style in the GeoServer that shall be used for the masking
 momo.maskingStyleName=state_filter

--- a/src/main/resources/META-INF/config/dev/momo.properties
+++ b/src/main/resources/META-INF/config/dev/momo.properties
@@ -6,7 +6,14 @@
 http.timeout=30000
 
 # The URL of the geoserver interceptor in this project
-shogun2.geoserverInterceptorUrl=/momo/geoserver.action
+momo.publicInterceptGeoServerAction=/momo/geoserver.action
+
+# GeoServer BaseUrl
+geoserver.baseUrl=http://188.40.113.28/geoserver/momo/ows/
+
+# PrintServlet BaseUrl and interceptor
+printservlet.baseUrl=http://188.40.113.28/print-servlet-3.6.0/
+printservlet.interceptorUrl=/momo/print
 
 # The name of the SUPERADMIN role
 # (a user with this role is allowed to do everything)

--- a/src/main/resources/META-INF/config/prod/momo.properties
+++ b/src/main/resources/META-INF/config/prod/momo.properties
@@ -6,7 +6,14 @@
 http.timeout=30000
 
 # The URL of the geoserver interceptor in this project
-shogun2.geoserverInterceptorUrl=/momo/geoserver.action
+momo.publicInterceptGeoServerAction=/momo/geoserver.action
+
+# GeoServer BaseUrl
+geoserver.baseUrl=http://188.40.113.28/geoserver/momo/ows/
+
+# PrintServlet BaseUrl and interceptor
+printservlet.baseUrl=http://188.40.113.28/print-servlet-3.6.0/
+printservlet.interceptorUrl=/momo/print
 
 # The name of the SUPERADMIN role
 # (a user with this role is allowed to do everything)
@@ -16,10 +23,10 @@ role.superAdminRoleName=ROLE_ADMIN
 role.defaultUserRoleName=ROLE_USER
 
 # The name of the feature type that is used to mask/restrict GetMap requests
-momo.maskingFeatureType=momo:Aimag_boundary
+momo.maskingFeatureType=momo:aimag_boundary
 
 # The name of the property of the maskingFeatureType from above that is used to mask/restrict GetMap requests
-momo.maskingPropertyName=Aimag_ID
+momo.maskingPropertyName=aimag_id
 
 # The name of the SLD style in the GeoServer that shall be used for the masking
 momo.maskingStyleName=state_filter

--- a/src/main/resources/META-INF/spring/ci/momo-context-initialize-beans.xml
+++ b/src/main/resources/META-INF/spring/ci/momo-context-initialize-beans.xml
@@ -275,6 +275,7 @@
         <ref bean="stepBackModule" />
         <ref bean="stepForwardModule" />
         <ref bean="hsiToolsModule" />
+        <ref bean="printModule" />
         <ref bean="showMeasureToolsModule" />
         <ref bean="showRedliningToolsModule" />
         <ref bean="showWorkstateToolsModule" />
@@ -6504,6 +6505,17 @@
         </property>
     </bean>
 
+    <bean id="printModule" class="de.terrestris.shogun2.model.module.Button">
+        <property name="name" value="Print button" />
+        <property name="xtype" value="momo-button-print" />
+        <property name="properties">
+            <util:map>
+                <entry key="printUrl" value="${printservlet.interceptorUrl}"/>
+                <entry key="ui" value="momo-tools" />
+            </util:map>
+        </property>
+    </bean>
+
     <bean id="showMeasureToolsModule" class="de.terrestris.shogun2.model.module.Button">
         <property name="name" value="Show measure tools button" />
         <property name="xtype" value="momo-button-showmeasuretoolspanel" />
@@ -6574,6 +6586,7 @@
                 <ref bean="stepBackModule" />
                 <ref bean="stepForwardModule" />
                 <ref bean="hsiToolsModule" />
+                <ref bean="printModule" />
                 <ref bean="showMeasureToolsModule" />
                 <ref bean="showRedliningToolsModule" />
                 <ref bean="showWorkstateToolsModule" />

--- a/src/main/resources/META-INF/spring/dev/momo-context-initialize-beans.xml
+++ b/src/main/resources/META-INF/spring/dev/momo-context-initialize-beans.xml
@@ -275,6 +275,7 @@
         <ref bean="stepBackModule" />
         <ref bean="stepForwardModule" />
         <ref bean="hsiToolsModule" />
+        <ref bean="printModule" />
         <ref bean="showMeasureToolsModule" />
         <ref bean="showRedliningToolsModule" />
         <ref bean="showWorkstateToolsModule" />
@@ -6504,6 +6505,17 @@
         </property>
     </bean>
 
+    <bean id="printModule" class="de.terrestris.shogun2.model.module.Button">
+        <property name="name" value="Print button" />
+        <property name="xtype" value="momo-button-print" />
+        <property name="properties">
+            <util:map>
+                <entry key="printUrl" value="${printservlet.interceptorUrl}"/>
+                <entry key="ui" value="momo-tools" />
+            </util:map>
+        </property>
+    </bean>
+
     <bean id="showMeasureToolsModule" class="de.terrestris.shogun2.model.module.Button">
         <property name="name" value="Show measure tools button" />
         <property name="xtype" value="momo-button-showmeasuretoolspanel" />
@@ -6574,6 +6586,7 @@
                 <ref bean="stepBackModule" />
                 <ref bean="stepForwardModule" />
                 <ref bean="hsiToolsModule" />
+                <ref bean="printModule" />
                 <ref bean="showMeasureToolsModule" />
                 <ref bean="showRedliningToolsModule" />
                 <ref bean="showWorkstateToolsModule" />

--- a/src/main/resources/META-INF/spring/momo-context-security.xml
+++ b/src/main/resources/META-INF/spring/momo-context-security.xml
@@ -22,11 +22,16 @@
     <http pattern="/login/build/**" security="none" />
     <http pattern="/login/resources/**" security="none" />
 
+    <!-- Remove security for print requests, where we cannot include csrf tokens -->
+    <http pattern="/print/**" security="none" />
+
+
+
     <!-- Web/URL security -->
     <http auto-config="true" use-expressions="true" access-decision-manager-ref="accessDecisionManager">
 
         <!-- Login/Logout -->
-        <form-login 
+        <form-login
             login-page="/login"
             login-processing-url="/doLogin"
             username-parameter="username"

--- a/src/main/resources/META-INF/spring/momo-context.xml
+++ b/src/main/resources/META-INF/spring/momo-context.xml
@@ -40,6 +40,23 @@
         </property>
     </bean>
 
+    <bean id="publicInterceptGeoServerAction" class="java.lang.String">
+        <constructor-arg value="${momo.publicInterceptGeoServerAction}"></constructor-arg>
+    </bean>
+
+    <bean id="geoServerBaseUrl" class="java.lang.String">
+       <constructor-arg value="${geoserver.baseUrl}"></constructor-arg>
+    </bean>
+
+    <!-- Print servlet -->
+    <bean id="printservletBaseUrl" class="java.lang.String">
+        <constructor-arg value="${printservlet.baseUrl}"></constructor-arg>
+    </bean>
+
+    <bean id="printservletInterceptorUrl" class="java.lang.String">
+        <constructor-arg value="${printservlet.interceptorUrl}"></constructor-arg>
+    </bean>
+
     <!-- The default mail sender -->
     <bean id="defaultMailSender" class="java.lang.String">
         <constructor-arg value="${mail.defaultSender}"></constructor-arg>

--- a/src/main/resources/META-INF/spring/prod/momo-context-initialize-beans.xml
+++ b/src/main/resources/META-INF/spring/prod/momo-context-initialize-beans.xml
@@ -275,6 +275,7 @@
         <ref bean="stepBackModule" />
         <ref bean="stepForwardModule" />
         <ref bean="hsiToolsModule" />
+        <ref bean="printModule" />
         <ref bean="showMeasureToolsModule" />
         <ref bean="showRedliningToolsModule" />
         <ref bean="showWorkstateToolsModule" />
@@ -6504,6 +6505,17 @@
         </property>
     </bean>
 
+    <bean id="printModule" class="de.terrestris.shogun2.model.module.Button">
+        <property name="name" value="Print button" />
+        <property name="xtype" value="momo-button-print" />
+        <property name="properties">
+            <util:map>
+                <entry key="printUrl" value="${printservlet.interceptorUrl}"/>
+                <entry key="ui" value="momo-tools" />
+            </util:map>
+        </property>
+    </bean>
+
     <bean id="showMeasureToolsModule" class="de.terrestris.shogun2.model.module.Button">
         <property name="name" value="Show measure tools button" />
         <property name="xtype" value="momo-button-showmeasuretoolspanel" />
@@ -6574,6 +6586,7 @@
                 <ref bean="stepBackModule" />
                 <ref bean="stepForwardModule" />
                 <ref bean="hsiToolsModule" />
+                <ref bean="printModule" />
                 <ref bean="showMeasureToolsModule" />
                 <ref bean="showRedliningToolsModule" />
                 <ref bean="showWorkstateToolsModule" />

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -45,6 +45,7 @@
 
     <servlet-mapping>
         <servlet-name>momo</servlet-name>
+        <url-pattern>/</url-pattern>
         <url-pattern>*.action</url-pattern>
         <url-pattern>/rest/*</url-pattern>
     </servlet-mapping>


### PR DESCRIPTION
This PR introduces a print module for momo project.

TODO
At the moment a pretty thin print controller, that only requests the prind result from server as document in predefined format, is implemented. Due to specification, the print resolutions up to 576 dpi and layouts from A4 to A0 must be supported, so the backend logic should be improved to create a print jobs and provide user a download link instead of direct download, what probably won't work for huge documents.

Corresponding PR in frontend: https://github.com/terrestris/momo3-frontend/pull/35

Please review @buehner 
