### PR TITLE
Persist uploader of a layer as owner; enable some permissions for ROLE_USER

### DIFF
--- a/src/main/java/de/terrestris/momo/model/MomoApplication.java
+++ b/src/main/java/de/terrestris/momo/model/MomoApplication.java
@@ -8,7 +8,6 @@ import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
 import javax.persistence.OrderColumn;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;

--- a/src/main/java/de/terrestris/momo/model/MomoLayer.java
+++ b/src/main/java/de/terrestris/momo/model/MomoLayer.java
@@ -8,6 +8,7 @@ import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
@@ -17,6 +18,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 import de.terrestris.momo.model.tree.LayerTreeLeaf;
+import de.terrestris.shogun2.model.User;
 import de.terrestris.shogun2.model.layer.Layer;
 
 /**
@@ -63,6 +65,12 @@ public class MomoLayer extends Layer {
 	@OneToMany(cascade = CascadeType.REMOVE)
 	@JoinColumn(name="LAYER_ID")
 	private List<LayerTreeLeaf> layerTreeLeaves;
+
+	/**
+	 *
+	 */
+	@ManyToOne
+	private User owner;
 
 	/**
 	 *
@@ -127,6 +135,34 @@ public class MomoLayer extends Layer {
 	}
 
 	/**
+	 * @return the metadataIdentifier
+	 */
+	public String getMetadataIdentifier() {
+		return metadataIdentifier;
+	}
+
+	/**
+	 * @param metadataIdentifier the metadataIdentifier to set
+	 */
+	public void setMetadataIdentifier(String metadataIdentifier) {
+		this.metadataIdentifier = metadataIdentifier;
+	}
+
+	/**
+	 * @return the owner
+	 */
+	public User getOwner() {
+		return owner;
+	}
+
+	/**
+	 * @param owner the owner to set
+	 */
+	public void setOwner(User owner) {
+		this.owner = owner;
+	}
+
+	/**
 	 * @see java.lang.Object#hashCode()
 	 *
 	 *      According to
@@ -175,20 +211,6 @@ public class MomoLayer extends Layer {
 	@Override
 	public String toString() {
 		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
-	}
-
-	/**
-	 * @return the metadataIdentifier
-	 */
-	public String getMetadataIdentifier() {
-		return metadataIdentifier;
-	}
-
-	/**
-	 * @param metadataIdentifier the metadataIdentifier to set
-	 */
-	public void setMetadataIdentifier(String metadataIdentifier) {
-		this.metadataIdentifier = metadataIdentifier;
 	}
 
 }

--- a/src/main/java/de/terrestris/momo/security/access/entity/ApplicationPermissionEvaluator.java
+++ b/src/main/java/de/terrestris/momo/security/access/entity/ApplicationPermissionEvaluator.java
@@ -1,0 +1,57 @@
+/**
+ *
+ */
+package de.terrestris.momo.security.access.entity;
+
+import de.terrestris.momo.model.MomoApplication;
+import de.terrestris.shogun2.model.User;
+import de.terrestris.shogun2.model.security.Permission;
+import de.terrestris.shogun2.security.access.entity.PersistentObjectPermissionEvaluator;
+
+/**
+ * @author Johannes Weskamm
+ * @param <E>
+ *
+ */
+public class ApplicationPermissionEvaluator<E extends MomoApplication> extends PersistentObjectPermissionEvaluator<E> {
+
+	/**
+	 * Default constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public ApplicationPermissionEvaluator() {
+		this((Class<E>) MomoApplication.class);
+	}
+
+	/**
+	 * Constructor for subclasses
+	 *
+	 * @param entityClass
+	 */
+	protected ApplicationPermissionEvaluator(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * Always grants right to READ and CREATE this entity.
+	 */
+	@Override
+	public boolean hasPermission(User user, E entity, Permission permission) {
+
+		// always grant READ right for this entity
+		if (permission.equals(Permission.READ)) {
+			LOG.trace("Granting READ for application.");
+			return true;
+		}
+
+		// always grant CREATE right for this entity
+		if (permission.equals(Permission.CREATE)) {
+			LOG.trace("Granting CREATE for application.");
+			return true;
+		}
+
+		// call parent implementation from SHOGun2
+		return super.hasPermission(user, entity, permission);
+	}
+
+}

--- a/src/main/java/de/terrestris/momo/security/access/entity/LayerAppearancePermissionEvaluator.java
+++ b/src/main/java/de/terrestris/momo/security/access/entity/LayerAppearancePermissionEvaluator.java
@@ -1,0 +1,63 @@
+/**
+ *
+ */
+package de.terrestris.momo.security.access.entity;
+
+import de.terrestris.shogun2.model.User;
+import de.terrestris.shogun2.model.layer.appearance.LayerAppearance;
+import de.terrestris.shogun2.model.security.Permission;
+import de.terrestris.shogun2.security.access.entity.PersistentObjectPermissionEvaluator;
+
+/**
+ * @author Johannes Weskamm
+ * @param <E>
+ *
+ */
+public class LayerAppearancePermissionEvaluator<E extends LayerAppearance> extends PersistentObjectPermissionEvaluator<E> {
+
+	/**
+	 * Default constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public LayerAppearancePermissionEvaluator() {
+		this((Class<E>) LayerAppearance.class);
+	}
+
+	/**
+	 * Constructor for subclasses
+	 *
+	 * @param entityClass
+	 */
+	protected LayerAppearancePermissionEvaluator(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * Always grants right to READ, UPDATE and CREATE this entity.
+	 */
+	@Override
+	public boolean hasPermission(User user, E entity, Permission permission) {
+
+		// always grant READ right for this entity
+		if (permission.equals(Permission.READ)) {
+			LOG.trace("Granting READ for LayerAppearance.");
+			return true;
+		}
+
+		// always grant CREATE right for this entity
+		if (permission.equals(Permission.CREATE)) {
+			LOG.trace("Granting CREATE for LayerAppearance.");
+			return true;
+		}
+
+		// always grant CREATE right for this entity
+		if (permission.equals(Permission.UPDATE)) {
+			LOG.trace("Granting CREATE for LayerAppearance.");
+			return true;
+		}
+
+		// call parent implementation from SHOGun2
+		return super.hasPermission(user, entity, permission);
+	}
+
+}

--- a/src/main/java/de/terrestris/momo/security/access/entity/MomoLayerPermissionEvaluator.java
+++ b/src/main/java/de/terrestris/momo/security/access/entity/MomoLayerPermissionEvaluator.java
@@ -1,0 +1,64 @@
+/**
+ *
+ */
+package de.terrestris.momo.security.access.entity;
+
+import de.terrestris.momo.model.MomoLayer;
+import de.terrestris.shogun2.model.User;
+import de.terrestris.shogun2.model.security.Permission;
+import de.terrestris.shogun2.security.access.entity.PersistentObjectPermissionEvaluator;
+
+/**
+ * @author Johannes Weskamm
+ * @param <E>
+ *
+ */
+public class MomoLayerPermissionEvaluator<E extends MomoLayer> extends PersistentObjectPermissionEvaluator<E> {
+
+	/**
+	 * Default constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public MomoLayerPermissionEvaluator() {
+		this((Class<E>) MomoLayer.class);
+	}
+
+	/**
+	 * Constructor for subclasses
+	 *
+	 * @param entityClass
+	 */
+	protected MomoLayerPermissionEvaluator(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * Always grants right to READ, UPDATE and CREATE this entity.
+	 */
+	@Override
+	public boolean hasPermission(User user, E entity, Permission permission) {
+
+		// always grant READ right for this entity
+		if (permission.equals(Permission.READ)) {
+			LOG.trace("Granting READ for layer.");
+			return true;
+		}
+
+		// always grant CREATE right for this entity
+		if (permission.equals(Permission.CREATE)) {
+			LOG.trace("Granting CREATE for layer.");
+			return true;
+		}
+		// always grant CREATE right for this entity
+		if (permission.equals(Permission.UPDATE)) {
+			if (entity.getOwner().getId().equals(user.getId())) {
+				LOG.trace("Granting UPDATE for layer.");
+				return true;
+			}
+		}
+
+		// call parent implementation from SHOGun2
+		return super.hasPermission(user, entity, permission);
+	}
+
+}

--- a/src/main/java/de/terrestris/momo/security/access/entity/TreeNodePermissionEvaluator.java
+++ b/src/main/java/de/terrestris/momo/security/access/entity/TreeNodePermissionEvaluator.java
@@ -1,0 +1,63 @@
+/**
+ *
+ */
+package de.terrestris.momo.security.access.entity;
+
+import de.terrestris.shogun2.model.User;
+import de.terrestris.shogun2.model.security.Permission;
+import de.terrestris.shogun2.model.tree.TreeNode;
+import de.terrestris.shogun2.security.access.entity.PersistentObjectPermissionEvaluator;
+
+/**
+ * @author Johannes Weskamm
+ * @param <E>
+ *
+ */
+public class TreeNodePermissionEvaluator<E extends TreeNode> extends PersistentObjectPermissionEvaluator<E> {
+
+	/**
+	 * Default constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public TreeNodePermissionEvaluator() {
+		this((Class<E>) TreeNode.class);
+	}
+
+	/**
+	 * Constructor for subclasses
+	 *
+	 * @param entityClass
+	 */
+	protected TreeNodePermissionEvaluator(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * Always grants right to READ, UPDATE and CREATE this entity.
+	 */
+	@Override
+	public boolean hasPermission(User user, E entity, Permission permission) {
+
+		// always grant READ right for this entity
+		if (permission.equals(Permission.READ)) {
+			LOG.trace("Granting READ for TreeNode.");
+			return true;
+		}
+
+		// always grant CREATE right for this entity
+		if (permission.equals(Permission.CREATE)) {
+			LOG.trace("Granting CREATE for TreeNode.");
+			return true;
+		}
+
+		// always grant CREATE right for this entity
+		if (permission.equals(Permission.UPDATE)) {
+			LOG.trace("Granting UPDATE for TreeNode.");
+			return true;
+		}
+
+		// call parent implementation from SHOGun2
+		return super.hasPermission(user, entity, permission);
+	}
+
+}

--- a/src/main/java/de/terrestris/momo/security/access/factory/MomoPermissionEvaluatorFactory.java
+++ b/src/main/java/de/terrestris/momo/security/access/factory/MomoPermissionEvaluatorFactory.java
@@ -3,11 +3,19 @@
  */
 package de.terrestris.momo.security.access.factory;
 
+import de.terrestris.momo.model.MomoApplication;
+import de.terrestris.momo.model.MomoLayer;
 import de.terrestris.momo.model.tree.DocumentTreeFolder;
 import de.terrestris.momo.model.tree.DocumentTreeLeaf;
+import de.terrestris.momo.security.access.entity.ApplicationPermissionEvaluator;
 import de.terrestris.momo.security.access.entity.DocumentTreeFolderPermissionEvaluator;
 import de.terrestris.momo.security.access.entity.DocumentTreeLeafPermissionEvaluator;
+import de.terrestris.momo.security.access.entity.LayerAppearancePermissionEvaluator;
+import de.terrestris.momo.security.access.entity.MomoLayerPermissionEvaluator;
+import de.terrestris.momo.security.access.entity.TreeNodePermissionEvaluator;
 import de.terrestris.shogun2.model.PersistentObject;
+import de.terrestris.shogun2.model.layer.appearance.LayerAppearance;
+import de.terrestris.shogun2.model.tree.TreeNode;
 import de.terrestris.shogun2.security.access.entity.PersistentObjectPermissionEvaluator;
 import de.terrestris.shogun2.security.access.factory.EntityPermissionEvaluatorFactory;
 
@@ -31,6 +39,18 @@ public class MomoPermissionEvaluatorFactory<E extends PersistentObject> extends 
 		}
 		if(DocumentTreeLeaf.class.isAssignableFrom(entityClass)) {
 			return new DocumentTreeLeafPermissionEvaluator();
+		}
+		if(MomoLayer.class.isAssignableFrom(entityClass)) {
+			return new MomoLayerPermissionEvaluator();
+		}
+		if(LayerAppearance.class.isAssignableFrom(entityClass)) {
+			return new LayerAppearancePermissionEvaluator();
+		}
+		if(MomoApplication.class.isAssignableFrom(entityClass)) {
+			return new ApplicationPermissionEvaluator();
+		}
+		if(TreeNode.class.isAssignableFrom(entityClass)) {
+			return new TreeNodePermissionEvaluator();
 		}
 
 		// call SHOGun2 implementation otherwise

--- a/src/main/java/de/terrestris/momo/service/GeoServerImporterService.java
+++ b/src/main/java/de/terrestris/momo/service/GeoServerImporterService.java
@@ -327,6 +327,8 @@ public class GeoServerImporterService {
 		layer.setDataType(layerDataType);
 		layer.setHoverable(true);
 
+		layer.setOwner(currentUser);
+
 		layerService.saveOrUpdate(layer);
 		layerService.addAndSaveUserPermissions(layer, currentUser, Permission.ADMIN);
 


### PR DESCRIPTION
Persisted layers will from now on have an "owner" set. Existing layers will have a `null` owner.
Also granted some Permission to the ROLE_USER, since users can now register themselves and need to be able to upload layers