### PR TITLE
Add maven-release-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,13 @@
 
     <name>momo</name>
 
+    <scm>
+        <url>https://github.com/terrestris/momo3-backend</url>
+        <connection>scm:git:git://github.com/terrestris/momo3-backend.git</connection>
+        <developerConnection>scm:git:git@github.com:terrestris/momo3-backend.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
     <repositories>
         <repository>
             <id>GeoSolutions</id>
@@ -47,8 +54,8 @@
         <!-- The type of connection to use (connection or developerConnection) -->
         <maven-scm-plugin.connection-type>developerConnection</maven-scm-plugin.connection-type>
 
-        <!-- Skip the creation of the javascript applications (login, client,
-             admin) per default. Create with productio profile only. -->
+        <!-- Skip the creation of the JavaScript applications (login, client,
+             admin) per default. Create with production profile only. -->
         <skip-build-javascript-resources>true</skip-build-javascript-resources>
 
         <shogun2.version>0.1.3-SNAPSHOT</shogun2.version>
@@ -64,6 +71,7 @@
         <maven-exec-plugin.version>1.5.0</maven-exec-plugin.version>
         <maven-tomcat-plugin.version>2.2</maven-tomcat-plugin.version>
         <maven-war-plugin.version>2.6</maven-war-plugin.version>
+        <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
 
         <commons-fileupload.version>1.3.1</commons-fileupload.version>
         <commons-dbutils.version>1.6</commons-dbutils.version>
@@ -284,7 +292,6 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-<!--                             <skip>true</skip> -->
                             <skip>${skip-build-javascript-resources}</skip>
                             <workingDirectory>${basedir}/src/main/webapp/client/</workingDirectory>
                             <executable>${sencha.cmd.executable}</executable>
@@ -396,7 +403,7 @@
             </plugin>
 
             <!-- Checkout/clone the shogun2 client to this application. For
-                checkout just run mvn scm:checkout in your app directory -->
+                 checkout just run mvn scm:checkout in your app directory -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-scm-plugin</artifactId>
@@ -415,7 +422,32 @@
                 </configuration>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>${maven-release-plugin.version}</version>
+                <configuration>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <tagNameFormat>v@{project.version}</tagNameFormat>
+                    <!-- The version to release, e.g. 0.0.1 -->
+                    <releaseVersion>${releaseVersion}</releaseVersion>
+                    <!-- The version to set for the next development
+                         cycle, e.g. 0.0.2-SNAPSHOT -->
+                    <developmentVersion>${developmentVersion}</developmentVersion>
+                    <!-- Disable the release profile that is part of the
+                         Maven Super POM since we are using our own profile -->
+                    <useReleaseProfile>false</useReleaseProfile>
+                    <goals>deploy</goals>
+                    <allowTimestampedSnapshots>true</allowTimestampedSnapshots>
+                    <arguments>
+                        <!-- Don't build the JavaScript resources -->
+                        -Dskip-build-javascript-resources=true
+                    </arguments>
+                </configuration>
+            </plugin>
+
         </plugins>
+
         <pluginManagement>
             <plugins>
                 <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->

--- a/scripts/doRelease.sh
+++ b/scripts/doRelease.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Stop at first command failure
+set -e
+
+read -p "Do you really want to create a release based on the current state (y/n)? "
+
+# Check if prompted to continue
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Exiting..."
+    exit 1
+fi
+
+# Check if the input parameter RELEASE_VERSION is valid
+RELEASE_VERSION="$1"
+if [[ ! $RELEASE_VERSION =~ ^([0-9]+\.[0-9]+\.[0-9])$ ]]; then
+    echo "Error: RELEASE_VERSION must be in X.Y.Z format, but was $RELEASE_VERSION"
+    exit 1
+fi
+
+# Check if the input parameter DEVELOPMENT_VERSION is valid
+DEVELOPMENT_VERSION="$2"
+if [[ ! $DEVELOPMENT_VERSION =~ ^([0-9]+\.[0-9]+\.[0-9])(\-SNAPSHOT)$ ]]; then
+    echo "Error: DEVELOPMENT_VERSION must be in X.Y.Z-SNAPSHOT format, but was $DEVELOPMENT_VERSION"
+    exit 1
+fi
+
+SCRIPTDIR=`dirname "$0"`
+
+pushd $SCRIPTDIR/..
+
+mvn release:clean
+mvn release:prepare --batch-mode -DreleaseVersion=$RELEASE_VERSION -DdevelopmentVersion=$DEVELOPMENT_VERSION
+mvn release:perform --batch-mode
+
+popd
+


### PR DESCRIPTION
This adds the `maven-release-plugin` to tag new releases of this project.

Basically it's possible to just use the plugin's commands (e.g. `mvn release:clean`) to create new tags, but the recommended usage is to call the `doRelease` script:

```
./scripts/doRelease.sh 0.0.1 0.0.2-SNAPSHOT
```
