### PR TITLE
Automated release process

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,22 +34,6 @@
              available in the PATH. -->
         <sencha.cmd.executable>sencha</sencha.cmd.executable>
 
-        <!-- SCM settings used to checkout other git repositories into this
-             webapp, e.g. the momo3-frontend -->
-
-        <!--
-         | IMPORTANT:
-         |
-         | When you invoke tasks that need the following property, like…
-         |     mvn scm:checkout
-         | …remember to pass your github handle via the commandline:
-         |     mvn scm:checkout -Dmaven-scm-plugin.git-username=YOUR_GITHUB_ID
-         |
-         +-->
-        <maven-scm-plugin.git-username>{{USERNAME}}</maven-scm-plugin.git-username>
-        <!-- The type of connection to use (connection or developerConnection) -->
-        <maven-scm-plugin.connection-type>developerConnection</maven-scm-plugin.connection-type>
-
         <!-- Skip the creation of the JavaScript applications (login, client,
              admin) per default. Create with production profile only. -->
         <skip-build-javascript-resources>true</skip-build-javascript-resources>
@@ -398,26 +382,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-
-            <!-- Checkout/clone the shogun2 client to this application. For
-                 checkout just run mvn scm:checkout in your app directory -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-scm-plugin</artifactId>
-                <version>${maven-scm-plugin.version}</version>
-                <configuration>
-                    <!-- The directory to checkout the sources to for the
-                        bootstrap and checkout goals -->
-                    <checkoutDirectory>${project.basedir}/src/main/webapp/client</checkoutDirectory>
-                    <!-- The type of connection to use (connection or developerConnection) -->
-                    <connectionType>${maven-scm-plugin.connection-type}</connectionType>
-                    <!-- The base repository -->
-                    <connectionUrl>scm:git:https://github.com/terrestris/momo3-frontend.git</connectionUrl>
-                    <!-- IMPORTANT: Set your git username here! (Assuming
-                        you have fork already) -->
-                    <developerConnectionUrl>scm:git:https://github.com/${maven-scm-plugin.git-username}/momo3-frontend.git</developerConnectionUrl>
-                </configuration>
             </plugin>
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,8 @@
 
         <slf4j.version>1.5.11</slf4j.version>
 
+        <github-release-plugin.version>1.2.0</github-release-plugin.version>
+
         <hamcrest.version>1.3</hamcrest.version>
         <spring.version>4.3.7.RELEASE</spring.version>
         <mockito.version>1.10.19</mockito.version>
@@ -419,26 +421,30 @@
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>${maven-release-plugin.version}</version>
+                <groupId>de.jutzig</groupId>
+                <artifactId>github-release-plugin</artifactId>
+                <version>${github-release-plugin.version}</version>
                 <configuration>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
-                    <tagNameFormat>v@{project.version}</tagNameFormat>
-                    <!-- The version to release, e.g. 0.0.1 -->
-                    <releaseVersion>${releaseVersion}</releaseVersion>
-                    <!-- The version to set for the next development
-                         cycle, e.g. 0.0.2-SNAPSHOT -->
-                    <developmentVersion>${developmentVersion}</developmentVersion>
-                    <!-- Disable the release profile that is part of the
-                         Maven Super POM since we are using our own profile -->
-                    <useReleaseProfile>false</useReleaseProfile>
-                    <goals>deploy</goals>
-                    <allowTimestampedSnapshots>true</allowTimestampedSnapshots>
-                    <arguments>
-                        <!-- Don't build the JavaScript resources -->
-                        -Dskip-build-javascript-resources=true
-                    </arguments>
+                    <!-- The description to be used in the release, may be
+                         edited afterwards via GitHub UI. -->
+                    <description>${releaseDescription}</description>
+                    <!-- The name of the release, typically the current
+                         version number. -->
+                    <releaseName>${project.version}</releaseName>
+                    <!-- The name of the corresponding relase tag, typically
+                         the current version number. -->
+                    <tag>${project.version}</tag>
+                    <!-- A list of files to be added to the release, typically
+                         we want to add the build artifact of the current
+                         release only. -->
+                    <fileSets>
+                        <fileSet>
+                            <directory>${project.build.directory}</directory>
+                            <includes>
+                                <include>${project.artifactId}*.war</include>
+                            </includes>
+                        </fileSet>
+                    </fileSets>
                 </configuration>
             </plugin>
 
@@ -561,6 +567,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>${slf4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>de.jutzig</groupId>
+            <artifactId>github-release-plugin</artifactId>
+            <version>${github-release-plugin.version}</version>
         </dependency>
 
         <!-- Spring test -->

--- a/pom.xml
+++ b/pom.xml
@@ -12,9 +12,8 @@
 
     <scm>
         <url>https://github.com/terrestris/momo3-backend</url>
-        <connection>scm:git:git://github.com/terrestris/momo3-backend.git</connection>
+        <connection>scm:git:git@github.com:terrestris/momo3-backend.git</connection>
         <developerConnection>scm:git:git@github.com:terrestris/momo3-backend.git</developerConnection>
-        <tag>HEAD</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project
-    xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -474,7 +471,7 @@
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>
-                                        <ignore></ignore>
+                                        <ignore />
                                     </action>
                                 </pluginExecution>
                             </pluginExecutions>


### PR DESCRIPTION
Within this PR you'll find an easy and flexible solution for automated project release tagging.

To perform a release, just call:

```
./scripts/doRelease.sh [RELEASE_VERSION] [NEXT_DEV_VERSION] [RELEASE_DESCRIPTION]
``` 

Example call:

```
./scripts/doRelease.sh 0.0.1 0.0.2-SNAPSHOT "Release me"
``` 

The script triggers the release process as follows:
  * Set the pom's version to the release version.
  * Build the application (target war).
  * Commit the changes (version change in pom.xml) to the main repository.
  * Create and commit a new release tag.
  * Upload the build artifact to the release.
  * Set the pom's version to the next development version.
  * Commit the changes (version change in pom.xml) to the main repository.

Important notes and prerequisites:
  * Add your public SSH key (needed by the maven-svm-plugin) to your GitHub account, if not already done.
  * Add the following block to your local maven `settings.xml` (needed by the github-release-plugin):
```xml
<server>
    <id>github</id>
    <username>[YOUR_USERNAME]</username>
    <password>[YOUR_PASSWORT]</password>
</server>
```
  * Ensure you have a clean checkout of the project without any unpublished changes.
  * Ensure the project can be build locally.

And *really* important, especially for any potential upcoming usage of the build artifact: The artifact will be build without any profile and therefore without any configuration files that will be needed to run it!
