### PR TITLE
Inherit permissions of layer from application

### DIFF
--- a/src/main/java/de/terrestris/momo/model/MomoLayer.java
+++ b/src/main/java/de/terrestris/momo/model/MomoLayer.java
@@ -17,7 +17,10 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 import de.terrestris.momo.model.tree.LayerTreeLeaf;
+import de.terrestris.momo.util.serializer.MomoLayerSerializer;
 import de.terrestris.shogun2.model.User;
 import de.terrestris.shogun2.model.layer.Layer;
 
@@ -27,6 +30,7 @@ import de.terrestris.shogun2.model.layer.Layer;
  */
 @Entity
 @Table
+@JsonSerialize(using=MomoLayerSerializer.class)
 public class MomoLayer extends Layer {
 
 	/**

--- a/src/main/java/de/terrestris/momo/service/LayerTreeService.java
+++ b/src/main/java/de/terrestris/momo/service/LayerTreeService.java
@@ -59,6 +59,9 @@ public class LayerTreeService<E extends TreeNode, D extends LayerTreeDao<E>> ext
 	public List<Layer> getAllMapLayersFromTreeFolder(LayerTreeFolder treeFolder) throws Exception {
 
 		List<Layer> mapLayerList = new ArrayList<Layer>();
+		if (treeFolder == null) {
+			return mapLayerList;
+		}
 
 		List<TreeNode> children = treeFolder.getChildren();
 

--- a/src/main/java/de/terrestris/momo/util/serializer/MomoLayerSerializer.java
+++ b/src/main/java/de/terrestris/momo/util/serializer/MomoLayerSerializer.java
@@ -1,0 +1,114 @@
+package de.terrestris.momo.util.serializer;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.web.context.support.SpringBeanAutowiringSupport;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import de.terrestris.momo.dao.LayerTreeDao;
+import de.terrestris.momo.dao.MomoApplicationDao;
+import de.terrestris.momo.dao.MomoUserDao;
+import de.terrestris.momo.model.MomoApplication;
+import de.terrestris.momo.model.MomoLayer;
+import de.terrestris.momo.model.MomoUser;
+import de.terrestris.momo.model.tree.LayerTreeFolder;
+import de.terrestris.momo.security.access.entity.MomoPersistentObjectPermissionEvaluator;
+import de.terrestris.momo.service.LayerTreeService;
+import de.terrestris.momo.service.MomoApplicationService;
+import de.terrestris.momo.service.MomoUserService;
+import de.terrestris.momo.util.security.MomoSecurityUtil;
+import de.terrestris.shogun2.model.layer.Layer;
+import de.terrestris.shogun2.model.security.Permission;
+import de.terrestris.shogun2.model.tree.TreeNode;
+
+/**
+ *
+ * terrestris GmbH & Co. KG
+ * @author Andre Henn
+ * @author Daniel Koch
+ * @date 31.03.2017
+ *
+ * Custom serializer for instances of {@link MomoUser}
+ */
+public class MomoLayerSerializer extends StdSerializer<MomoLayer>{
+
+	private static final long serialVersionUID = 1L;
+
+	@Autowired
+	@Qualifier("momoUserService")
+	private MomoUserService<MomoUser, MomoUserDao <MomoUser>> momoUserService;
+
+	@Autowired
+	@Qualifier("momoApplicationService")
+	private MomoApplicationService<MomoApplication, MomoApplicationDao <MomoApplication>> momoApplicationService;
+
+	@Autowired
+	@Qualifier("layerTreeService")
+	private LayerTreeService<TreeNode, LayerTreeDao <TreeNode>> layerTreeService;
+
+	/**
+	 *
+	 */
+	public MomoLayerSerializer(){
+		this(null);
+	}
+
+	public MomoLayerSerializer(Class<MomoLayer> t) {
+		super(t);
+		SpringBeanAutowiringSupport.processInjectionBasedOnCurrentContext(this);
+	}
+
+
+	@Override
+	public void serialize(MomoLayer momoLayer, JsonGenerator generator, SerializerProvider provider) throws IOException {
+		generator.writeStartObject();
+
+		generator.writeNumberField("id", momoLayer.getId());
+		generator.writeBooleanField("chartable", momoLayer.getChartable() != null ? momoLayer.getChartable() : false);
+		generator.writeStringField("dataType", momoLayer.getDataType() != null ? momoLayer.getDataType() : StringUtils.EMPTY);
+		generator.writeStringField("description", momoLayer.getDescription() != null ? momoLayer.getDescription() : StringUtils.EMPTY);
+		generator.writeBooleanField("hoverable", momoLayer.getHoverable() != null ? momoLayer.getHoverable() : false);
+		generator.writeStringField("metadataIdentifier", momoLayer.getMetadataIdentifier() != null ? momoLayer.getMetadataIdentifier() : StringUtils.EMPTY);
+		generator.writeStringField("name", momoLayer.getName());
+		generator.writeBooleanField("spatiallyRestricted", momoLayer.getSpatiallyRestricted() != null ? momoLayer.getSpatiallyRestricted() : false);
+		generator.writeObjectField("appearance", momoLayer.getAppearance());
+		generator.writeObjectField("owner", momoLayer.getOwner());
+		generator.writeObjectField("source", momoLayer.getSource());
+
+		boolean readPermissionGrantedFromAnyApplication = false;
+		MomoUser currentUser = momoUserService.getUserBySession();
+		MomoPersistentObjectPermissionEvaluator<MomoLayer> permissionObjectEvaluator = new MomoPersistentObjectPermissionEvaluator<MomoLayer>();
+		boolean userHasReadPermission = permissionObjectEvaluator.hasPermission(currentUser, momoLayer, Permission.READ);
+
+		if (!userHasReadPermission && !MomoSecurityUtil.currentUserIsSuperAdmin()) {
+			// check if layer is contained in any application the user is allowed to see
+			List<MomoApplication> momoApplications = momoApplicationService.findAll();
+			for (MomoApplication momoApp : momoApplications) {
+				Integer layerTreeId = momoApp.getLayerTree().getId();
+				LayerTreeFolder layerTreeRootNode = (LayerTreeFolder) layerTreeService.findById(layerTreeId);
+				List<Layer> mapLayers = null;
+				try {
+					mapLayers = this.layerTreeService.getAllMapLayersFromTreeFolder(layerTreeRootNode);
+				} catch (Exception e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				}
+
+				if (mapLayers != null && mapLayers.contains(momoLayer)) {
+					readPermissionGrantedFromAnyApplication = true;
+				}
+			}
+		}
+
+		generator.writeBooleanField("readPermissionGrantedFromAnyApplication", readPermissionGrantedFromAnyApplication);
+		generator.writeEndObject();
+	}
+
+}

--- a/src/test/java/de/terrestris/momo/security/access/entity/MomoLayerPermissionEvaluatorTest.java
+++ b/src/test/java/de/terrestris/momo/security/access/entity/MomoLayerPermissionEvaluatorTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
@@ -26,11 +27,14 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import de.terrestris.momo.dao.MomoApplicationDao;
 import de.terrestris.momo.dao.UserGroupRoleDao;
+import de.terrestris.momo.model.MomoApplication;
 import de.terrestris.momo.model.MomoLayer;
 import de.terrestris.momo.model.MomoUser;
 import de.terrestris.momo.model.MomoUserGroup;
 import de.terrestris.momo.model.security.UserGroupRole;
+import de.terrestris.momo.service.MomoApplicationService;
 import de.terrestris.momo.service.UserGroupRoleService;
 import de.terrestris.momo.util.config.MomoConfigHolder;
 import de.terrestris.momo.util.security.MomoSecurityUtil;
@@ -139,6 +143,11 @@ public class MomoLayerPermissionEvaluatorTest {
 		permissionsToCheck.add(Permission.CREATE);
 		permissionsToCheck.add(Permission.UPDATE);
 		permissionsToCheck.add(Permission.DELETE);
+
+		MomoApplicationService<MomoApplication, MomoApplicationDao<MomoApplication>> momoApplicationServiceMock =
+				Mockito.mock(MomoApplicationService.class);
+		when(momoApplicationServiceMock.findAll()).thenReturn(new ArrayList<MomoApplication>());
+		momoLayerPermissionEvaluator.setMomoApplicationService(momoApplicationServiceMock);
 
 		for (Permission permission : permissionsToCheck) {
 			boolean permissionResult = momoLayerPermissionEvaluator.hasPermission(accessUser, testLayer, permission);
@@ -251,6 +260,11 @@ public class MomoLayerPermissionEvaluatorTest {
 		userRoles.add(role);
 
 		loginMockUser(userRoles);
+
+		MomoApplicationService<MomoApplication, MomoApplicationDao<MomoApplication>> momoApplicationServiceMock =
+				Mockito.mock(MomoApplicationService.class);
+		when(momoApplicationServiceMock.findAll()).thenReturn(new ArrayList<MomoApplication>());
+		momoLayerPermissionEvaluator.setMomoApplicationService(momoApplicationServiceMock);
 
 		boolean permissionResult = momoLayerPermissionEvaluator.hasPermission(accessUser, null, Permission.CREATE);
 		assertFalse(permissionResult);


### PR DESCRIPTION
This PR enhances the existing `MomoLayerPermissionEvaluator` such that usage of layers is also permitted iff the user has no `READ` permission for the certain layer entity but for an application that uses this layer. In order to distinguish these layers in the layer list (users role >= `ROLE_EDITOR`), a custom serializer has been introduced providing a `readPermissionGrantedFromAnyApplication` which holds this information.

In addition, since the layer is always passed through the `MomoLayerPermissionEvaluator`, the interceptor was cleaned up (e.g. masking values are not needed here anymore).

Please review.