### PR TITLE
Allow jetty context path to be configurable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,8 @@
              admin) per default. Create with production profile only. -->
         <skip-build-javascript-resources>true</skip-build-javascript-resources>
 
+        <jetty.contextPath>/</jetty.contextPath>
+
         <shogun2.version>0.1.3-SNAPSHOT</shogun2.version>
 
         <javax.jstl.version>1.2</javax.jstl.version>
@@ -99,7 +101,7 @@
                 <jdk.version>1.8</jdk.version>
                 <!-- Make Javadocs work in 1.8. Credits go to http://stackoverflow.com/a/26806103 -->
                 <javadoc.opts>-Xdoclint:none</javadoc.opts>
-                <jetty-maven-plugin.version>9.3.6.v20151106</jetty-maven-plugin.version>
+                <jetty-maven-plugin.version>9.4.6.v20170531</jetty-maven-plugin.version>
             </properties>
         </profile>
 
@@ -322,6 +324,7 @@
                          if any are detected -->
                     <scanIntervalSeconds>5</scanIntervalSeconds>
                     <webAppConfig>
+                        <contextPath>${jetty.contextPath}</contextPath>
                         <!-- Terminate the server on any startup exception -->
                         <throwUnavailableOnStartupException>true</throwUnavailableOnStartupException>
                     </webAppConfig>


### PR DESCRIPTION
This updates the jetty-maven-plugin to the lastest version and makes
the context path configurable via the command line using
eg. -Djetty.contextPath=/momo (version is only updated for the jdk8 profile).