### PR TITLE
Fixed uploading in and access to documenttree

### DIFF
--- a/src/main/java/de/terrestris/momo/security/access/entity/FilePermissionEvaluator.java
+++ b/src/main/java/de/terrestris/momo/security/access/entity/FilePermissionEvaluator.java
@@ -1,0 +1,55 @@
+/**
+ *
+ */
+package de.terrestris.momo.security.access.entity;
+
+import de.terrestris.momo.util.security.MomoSecurityUtil;
+import de.terrestris.shogun2.model.File;
+import de.terrestris.shogun2.model.User;
+import de.terrestris.shogun2.model.security.Permission;
+
+/**
+ * @author Johannes Weskamm
+ * @param <E>
+ *
+ */
+public class FilePermissionEvaluator<E extends File> extends MomoPersistentObjectPermissionEvaluator<E> {
+
+	/**
+	 * Default constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public FilePermissionEvaluator() {
+		this((Class<E>) File.class);
+	}
+
+	/**
+	 * Constructor for subclasses
+	 *
+	 * @param entityClass
+	 */
+	protected FilePermissionEvaluator(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	public boolean hasPermission(User user, E file, Permission permission) {
+
+		// all users with at least role_user are allowed to create files here
+		if (permission.equals(Permission.CREATE) && (file == null || file.getId() == null) &&
+				MomoSecurityUtil.currentUsersHighestRoleIsEditor() ||
+				MomoSecurityUtil.currentUserHasRoleSubAdmin() ||
+				MomoSecurityUtil.currentUserIsSuperAdmin()) {
+			return true;
+		}
+
+		/**
+		 * by default look for granted rights
+		 */
+		return hasDefaultMomoPermission(user, file, permission);
+	}
+
+}

--- a/src/main/java/de/terrestris/momo/security/access/factory/MomoPermissionEvaluatorFactory.java
+++ b/src/main/java/de/terrestris/momo/security/access/factory/MomoPermissionEvaluatorFactory.java
@@ -13,6 +13,7 @@ import de.terrestris.momo.model.tree.DocumentTreeLeaf;
 import de.terrestris.momo.security.access.entity.DocumentTreeFolderPermissionEvaluator;
 import de.terrestris.momo.security.access.entity.DocumentTreeLeafPermissionEvaluator;
 import de.terrestris.momo.security.access.entity.ExtentPermissionEvaluator;
+import de.terrestris.momo.security.access.entity.FilePermissionEvaluator;
 import de.terrestris.momo.security.access.entity.LayerAppearancePermissionEvaluator;
 import de.terrestris.momo.security.access.entity.MapConfigPermissionEvaluator;
 import de.terrestris.momo.security.access.entity.MapPermissionEvaluator;
@@ -25,6 +26,7 @@ import de.terrestris.momo.security.access.entity.MomoUserGroupPermissionEvaluato
 import de.terrestris.momo.security.access.entity.MomoUserPermissionEvaluator;
 import de.terrestris.momo.security.access.entity.TreeNodePermissionEvaluator;
 import de.terrestris.momo.security.access.entity.UserGroupRolePermissionEvaluator;
+import de.terrestris.shogun2.model.File;
 import de.terrestris.shogun2.model.PersistentObject;
 import de.terrestris.shogun2.model.Role;
 import de.terrestris.shogun2.model.interceptor.InterceptorRule;
@@ -100,6 +102,9 @@ public class MomoPermissionEvaluatorFactory<E extends PersistentObject> extends 
 		}
 		if(PermissionCollection.class.isAssignableFrom(entityClass)) {
 			return new PermissionCollectionPermissionEvaluator();
+		}
+		if(File.class.isAssignableFrom(entityClass)) {
+			return new FilePermissionEvaluator();
 		}
 
 		// The following types (and subclasses) may be READ by everyone

--- a/src/main/java/de/terrestris/momo/service/DocumentTreeService.java
+++ b/src/main/java/de/terrestris/momo/service/DocumentTreeService.java
@@ -116,7 +116,6 @@ public class DocumentTreeService<E extends TreeNode, D extends DocumentTreeDao<E
 	 * @return
 	 * @throws Exception
 	 */
-	@PreAuthorize("hasRole(@momoConfigHolder.getDefaultUserRoleName())")
 	public File getDocumentOfNode(Integer nodeId) throws Exception {
 
 		File fileToReturn = null;

--- a/src/main/java/de/terrestris/momo/service/MomoApplicationService.java
+++ b/src/main/java/de/terrestris/momo/service/MomoApplicationService.java
@@ -396,7 +396,6 @@ public class MomoApplicationService<E extends MomoApplication, D extends MomoApp
 	 * @return
 	 * @throws Exception
 	 */
-	@PreAuthorize("hasRole(@configHolder.getDefaultUserRoleName())")
 	public List<java.util.Map<String, Object>> getDocumentTreeRootNodeInfo(Integer id) throws Exception {
 		E app = this.findById(id);
 


### PR DESCRIPTION
This enables users with ROLE_EDITOR and up to upload documents to the documenttree.
This also enables anonymous users to view the documenttree by removing the @PreAuthorize annotation