### PR TITLE
Use SHOGun2 release version 0.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
         <jetty.contextPath>/</jetty.contextPath>
 
-        <shogun2.version>0.1.3-SNAPSHOT</shogun2.version>
+        <shogun2.version>0.1.3</shogun2.version>
 
         <javax.jstl.version>1.2</javax.jstl.version>
 


### PR DESCRIPTION
Title says it all. We should not use a SNAPSHOT version as long as there are no features, we'd like to use