### PR TITLE
Annotate read only transactional methods

### DIFF
--- a/src/main/java/de/terrestris/momo/service/ApplicationStateService.java
+++ b/src/main/java/de/terrestris/momo/service/ApplicationStateService.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import de.terrestris.momo.dao.ApplicationStateDao;
 import de.terrestris.momo.model.state.ApplicationState;
@@ -95,6 +96,7 @@ public class ApplicationStateService<E extends ApplicationState, D extends Appli
 	 * @return
 	 */
 	@PreAuthorize("hasRole(@configHolder.getDefaultUserRoleName())")
+	@Transactional(readOnly = true)
 	public Set<E> findByWebMapIdForCurrentUser(Integer webMapId) {
 		User currentUser = userService.getUserBySession();
 		return dao.findByWebMapIdAndUserId(webMapId, currentUser.getId());
@@ -106,6 +108,7 @@ public class ApplicationStateService<E extends ApplicationState, D extends Appli
 	 * @return
 	 */
 	@PreAuthorize("hasRole(@configHolder.getDefaultUserRoleName())")
+	@Transactional(readOnly = true)
 	public List<E> findAllWorkstatesOfUser(User owner) {
 		SimpleExpression eqOwner = Restrictions.eq("owner", owner);
 		return dao.findByCriteria(eqOwner);

--- a/src/main/java/de/terrestris/momo/service/DocumentTreeService.java
+++ b/src/main/java/de/terrestris/momo/service/DocumentTreeService.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import de.terrestris.momo.dao.DocumentTreeDao;
@@ -116,6 +117,7 @@ public class DocumentTreeService<E extends TreeNode, D extends DocumentTreeDao<E
 	 * @return
 	 * @throws Exception
 	 */
+	@Transactional(readOnly = true)
 	public File getDocumentOfNode(Integer nodeId) throws Exception {
 
 		File fileToReturn = null;
@@ -176,6 +178,7 @@ public class DocumentTreeService<E extends TreeNode, D extends DocumentTreeDao<E
 	 * @throws Exception
 	 */
 	@PreAuthorize("hasRole(@momoConfigHolder.getDefaultUserRoleName())")
+	@Transactional(readOnly = true)
 	private List<byte[]> getAllDocumentsOfFolder(DocumentTreeFolder folder) throws Exception {
 
 		List<byte[]> documentList = new ArrayList<byte[]>();

--- a/src/main/java/de/terrestris/momo/service/EntityPermissionService.java
+++ b/src/main/java/de/terrestris/momo/service/EntityPermissionService.java
@@ -78,6 +78,7 @@ public class EntityPermissionService<E extends PersistentObject> {
 	 * @throws NotFoundException
 	 */
 	@PreAuthorize("hasRole(@momoConfigHolder.getEditorRoleName())")
+	@Transactional(readOnly = true)
 	public EntityPermissionTypeEnvelope getEntityPermission(Integer entityId,
 			String targetEntity, Class<?> entityClass) throws ClassNotFoundException, NotFoundException {
 
@@ -182,6 +183,7 @@ public class EntityPermissionService<E extends PersistentObject> {
 	 * @param entityNameOfPermissionHolder
 	 * @throws Exception
 	 */
+	@Transactional(readOnly = true)
 	private void checkPathParametersWithEnvelopeObject(EntityPermissionTypeEnvelope envelope, String classNameOfTarget,
 			Integer entityIdOfTarget, String entityNameOfPermissionHolder) throws Exception {
 
@@ -220,6 +222,7 @@ public class EntityPermissionService<E extends PersistentObject> {
 	 * @param entity
 	 * @return
 	 */
+	@Transactional(readOnly = true)
 	private Set<EntityPermissionEnvelope> getUserGroupPermissions(PersistentObject entity) {
 
 		Map<UserGroup, PermissionCollection> groupPermissions = entity.getGroupPermissions();
@@ -243,6 +246,7 @@ public class EntityPermissionService<E extends PersistentObject> {
 	 * @param entity
 	 * @return
 	 */
+	@Transactional(readOnly = true)
 	private Set<EntityPermissionEnvelope> getUserPermissions(PersistentObject entity) {
 
 		Map<User, PermissionCollection> userPermissions = entity.getUserPermissions();

--- a/src/main/java/de/terrestris/momo/service/LayerTreeService.java
+++ b/src/main/java/de/terrestris/momo/service/LayerTreeService.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import de.terrestris.momo.dao.LayerTreeDao;
 import de.terrestris.momo.model.MomoLayer;
@@ -56,6 +57,7 @@ public class LayerTreeService<E extends TreeNode, D extends LayerTreeDao<E>> ext
 	 * @return
 	 * @throws Exception
 	 */
+	@Transactional(readOnly = true)
 	public List<Layer> getAllMapLayersFromTreeFolder(LayerTreeFolder treeFolder) throws Exception {
 
 		List<Layer> mapLayerList = new ArrayList<Layer>();

--- a/src/main/java/de/terrestris/momo/service/MetadataService.java
+++ b/src/main/java/de/terrestris/momo/service/MetadataService.java
@@ -89,7 +89,7 @@ public class MetadataService {
 
 		if (!transactionOperation.equalsIgnoreCase("CREATE") && layerId != null) {
 			MomoLayer layer = momoLayerService.findById(layerId);
-			
+
 			if (layer == null) {
 				String msg = "Could not find a layer with ID " + layerId;
 				LOG.error(msg);
@@ -97,9 +97,9 @@ public class MetadataService {
 			}
 			if (!transactionOperation.equalsIgnoreCase("CREATE")) {
 				String metaDataIdentifier = layer.getMetadataIdentifier();
-				
+
 				boolean isValidRecord = isValidRecord(metaDataIdentifier);
-				
+
 				if (!isValidRecord) {
 					String msg = "UUID is not valid";
 					LOG.error(msg);

--- a/src/main/java/de/terrestris/momo/service/MomoApplicationService.java
+++ b/src/main/java/de/terrestris/momo/service/MomoApplicationService.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import de.terrestris.momo.dao.DocumentTreeDao;
 import de.terrestris.momo.dao.LayerTreeDao;
@@ -396,6 +397,7 @@ public class MomoApplicationService<E extends MomoApplication, D extends MomoApp
 	 * @return
 	 * @throws Exception
 	 */
+	@Transactional(readOnly = true)
 	public List<java.util.Map<String, Object>> getDocumentTreeRootNodeInfo(Integer id) throws Exception {
 		E app = this.findById(id);
 

--- a/src/main/java/de/terrestris/momo/service/MomoLayerService.java
+++ b/src/main/java/de/terrestris/momo/service/MomoLayerService.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.access.prepost.PostAuthorize;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import de.terrestris.momo.dao.GeoserverPublisherDao;
 import de.terrestris.momo.dao.GeoserverReaderDao;
@@ -73,6 +74,7 @@ public class MomoLayerService<E extends MomoLayer, D extends MomoLayerDao<E>>
 	 * @throws Exception
 	 */
 	@PreAuthorize("isAuthenticated()")
+	@Transactional(readOnly = true)
 	public String getLayerExtent(Integer layerId) throws Exception {
 		MomoLayer layer = this.findById(layerId);
 		String extent = gsReaderDao.getLayerExtent(layer);
@@ -87,6 +89,7 @@ public class MomoLayerService<E extends MomoLayer, D extends MomoLayerDao<E>>
 	 * @return
 	 */
 	@PostAuthorize("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(returnObject, 'READ')")
+	@Transactional(readOnly = true)
 	public E findByUrlAndLayerNames(String url, String layerNames) {
 		if (url == null || layerNames == null) {
 			return null;
@@ -103,6 +106,7 @@ public class MomoLayerService<E extends MomoLayer, D extends MomoLayerDao<E>>
 	 * @throws Exception
 	 */
 	@PreAuthorize("isAuthenticated()")
+	@Transactional(readOnly = true)
 	public byte[] downloadLayers(List<Integer> layerIds) throws Exception {
 
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/src/main/java/de/terrestris/momo/service/MomoPasswordResetTokenService.java
+++ b/src/main/java/de/terrestris/momo/service/MomoPasswordResetTokenService.java
@@ -140,7 +140,6 @@ public class MomoPasswordResetTokenService<E extends PasswordResetToken, D exten
 	 * @throws URISyntaxException
 	 * @throws UnsupportedEncodingException
 	 */
-	@Transactional(readOnly = true)
 	public void sendResetPasswordMail(HttpServletRequest request, String email)
 			throws NoSuchMethodException, SecurityException,
 			InstantiationException, IllegalAccessException,

--- a/src/main/java/de/terrestris/momo/service/MomoPasswordResetTokenService.java
+++ b/src/main/java/de/terrestris/momo/service/MomoPasswordResetTokenService.java
@@ -14,6 +14,7 @@ import org.springframework.mail.SimpleMailMessage;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.util.UriUtils;
 
 import de.terrestris.momo.util.security.MomoSecurityUtil;
@@ -139,6 +140,7 @@ public class MomoPasswordResetTokenService<E extends PasswordResetToken, D exten
 	 * @throws URISyntaxException
 	 * @throws UnsupportedEncodingException
 	 */
+	@Transactional(readOnly = true)
 	public void sendResetPasswordMail(HttpServletRequest request, String email)
 			throws NoSuchMethodException, SecurityException,
 			InstantiationException, IllegalAccessException,
@@ -238,6 +240,7 @@ public class MomoPasswordResetTokenService<E extends PasswordResetToken, D exten
 	 * @return
 	 * @throws URISyntaxException
 	 */
+	@Transactional(readOnly = true)
 	private URI createResetPasswordURI(HttpServletRequest request,
 			PasswordResetToken resetPasswordToken) throws URISyntaxException {
 

--- a/src/main/java/de/terrestris/momo/service/MomoRegistrationTokenService.java
+++ b/src/main/java/de/terrestris/momo/service/MomoRegistrationTokenService.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.util.UriUtils;
 
 import de.terrestris.shogun2.dao.RegistrationTokenDao;
@@ -125,6 +126,7 @@ public class MomoRegistrationTokenService<E extends RegistrationToken, D extends
 	 * @throws URISyntaxException
 	 * @throws UnsupportedEncodingException
 	 */
+	@Transactional(readOnly = true)
 	public void sendRegistrationActivationMail(HttpServletRequest request,
 			User user) throws NoSuchMethodException, SecurityException,
 			InstantiationException, IllegalAccessException,

--- a/src/main/java/de/terrestris/momo/service/MomoUserService.java
+++ b/src/main/java/de/terrestris/momo/service/MomoUserService.java
@@ -22,6 +22,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import de.terrestris.momo.dao.MomoApplicationDao;
 import de.terrestris.momo.dao.MomoLayerDao;
@@ -247,6 +248,7 @@ public class MomoUserService<E extends MomoUser, D extends MomoUserDao<E>>
 	 * @throws NotFoundException
 	 * @throws AlreadyExistsException
 	 */
+	@Transactional(readOnly = true)
 	public void resendRegistrationTokenMail(HttpServletRequest request, String email)
 			throws NoSuchMethodException, SecurityException, InstantiationException,
 			IllegalAccessException, IllegalArgumentException, InvocationTargetException,
@@ -476,6 +478,7 @@ public class MomoUserService<E extends MomoUser, D extends MomoUserDao<E>>
 	 * @param group
 	 * @param user
 	 */
+	@Transactional(readOnly = true)
 	public void sendMailToSubadminOrSuperadmin(MomoUser subadminForGroup, MomoUser superadmin,
 			String wantedRole, MomoUserGroup group, MomoUser user) {
 		if (subadminForGroup != null) {
@@ -498,6 +501,7 @@ public class MomoUserService<E extends MomoUser, D extends MomoUserDao<E>>
 	 * @param group
 	 * @param user
 	 */
+	@Transactional(readOnly = true)
 	public void sendPermissionChangeMail(MomoUser receiver, String wantedRole,
 			MomoUserGroup group, MomoUser user) {
 

--- a/src/main/java/de/terrestris/momo/service/UserGroupRoleService.java
+++ b/src/main/java/de/terrestris/momo/service/UserGroupRoleService.java
@@ -15,6 +15,7 @@ import org.springframework.dao.PermissionDeniedDataAccessException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import de.terrestris.momo.dao.MomoUserDao;
 import de.terrestris.momo.dao.MomoUserGroupDao;
@@ -131,6 +132,7 @@ public class UserGroupRoleService<E extends UserGroupRole, D extends UserGroupRo
 	 * @param user
 	 * @return
 	 */
+	@Transactional(readOnly = true)
 	public Set<Role> findAllUserRoles(MomoUser user) {
 		Set<Role> allUserRoles = new HashSet<Role>();
 
@@ -151,6 +153,7 @@ public class UserGroupRoleService<E extends UserGroupRole, D extends UserGroupRo
 	 * @param user
 	 * @return
 	 */
+	@Transactional(readOnly = true)
 	public Set<MomoUserGroup> findAllUserGroups(MomoUser user) {
 		Set<MomoUserGroup> allUserGroups = new HashSet<MomoUserGroup>();
 
@@ -171,6 +174,7 @@ public class UserGroupRoleService<E extends UserGroupRole, D extends UserGroupRo
 	 * @param userGroup
 	 * @return
 	 */
+	@Transactional(readOnly = true)
 	public Set<Role> findAllUserGroupRoles(MomoUserGroup userGroup) {
 		Set<Role> allUserGroupRoles = new HashSet<Role>();
 
@@ -191,6 +195,7 @@ public class UserGroupRoleService<E extends UserGroupRole, D extends UserGroupRo
 	 * @param userGroup
 	 * @return
 	 */
+	@Transactional(readOnly = true)
 	public Set<MomoUser> findAllUserGroupMembers(MomoUserGroup userGroup) {
 		Set<MomoUser> allUserGroupMembers = new HashSet<MomoUser>();
 
@@ -212,6 +217,7 @@ public class UserGroupRoleService<E extends UserGroupRole, D extends UserGroupRo
 	 * @return
 	 */
 	@SuppressWarnings("unchecked")
+	@Transactional(readOnly = true)
 	public List<UserGroupRole> findUserGroupRolesBy(MomoUser user) {
 		return (List<UserGroupRole>) this.dao.findAllWhereFieldEquals(
 				"user", user);
@@ -223,6 +229,7 @@ public class UserGroupRoleService<E extends UserGroupRole, D extends UserGroupRo
 	 * @return
 	 */
 	@SuppressWarnings("unchecked")
+	@Transactional(readOnly = true)
 	public List<UserGroupRole> findUserGroupRolesBy(MomoUserGroup userGroup) {
 		return (List<UserGroupRole>) this.dao.findAllWhereFieldEquals(
 				"group", userGroup);
@@ -234,6 +241,7 @@ public class UserGroupRoleService<E extends UserGroupRole, D extends UserGroupRo
 	 * @return
 	 */
 	@SuppressWarnings("unchecked")
+	@Transactional(readOnly = true)
 	public List<UserGroupRole> findUserGroupRolesBy(Role role) {
 		return (List<UserGroupRole>) this.dao.findAllWhereFieldEquals(
 				"role", role);
@@ -246,6 +254,7 @@ public class UserGroupRoleService<E extends UserGroupRole, D extends UserGroupRo
 	 * @return
 	 */
 	@SuppressWarnings("unchecked")
+	@Transactional(readOnly = true)
 	public List<UserGroupRole> findUserGroupRolesBy(MomoUser user, MomoUserGroup userGroup) {
 
 		final Criterion and = Restrictions.and(
@@ -264,6 +273,7 @@ public class UserGroupRoleService<E extends UserGroupRole, D extends UserGroupRo
 	 * @return
 	 */
 	@SuppressWarnings("unchecked")
+	@Transactional(readOnly = true)
 	public List<UserGroupRole> findUserGroupRolesBy(MomoUser user, MomoUserGroup userGroup, Role role) {
 		final Criterion and = Restrictions.and(
 				Restrictions.eq("user", user),
@@ -280,6 +290,7 @@ public class UserGroupRoleService<E extends UserGroupRole, D extends UserGroupRo
 	 * @param userGroup
 	 * @return
 	 */
+	@Transactional(readOnly = true)
 	public boolean isUserMemberInUserGroup(MomoUser user, MomoUserGroup userGroup) {
 		final Criterion and = Restrictions.and(
 				Restrictions.eq("user", user),
@@ -296,6 +307,7 @@ public class UserGroupRoleService<E extends UserGroupRole, D extends UserGroupRo
 	 * @param role
 	 * @return
 	 */
+	@Transactional(readOnly = true)
 	public boolean hasUserRoleInGroup(MomoUser user, MomoUserGroup userGroup, Role role) {
 		final Criterion and = Restrictions.and(
 				Restrictions.eq("user", user),
@@ -490,6 +502,7 @@ public class UserGroupRoleService<E extends UserGroupRole, D extends UserGroupRo
 	 * @param group
 	 * @param user
 	 */
+	@Transactional(readOnly = true)
 	public void sendPermissionChangeMail(MomoUser receiver, String givenRole,
 			MomoUserGroup group) {
 


### PR DESCRIPTION
This will assure that transactional read-only methods will never persist anything (which might happen due to autocommits if a mangaged, persisted entity would be manipulated within a transactional method that does not have a `readOnly = true` annotation)