### PR TITLE
Fix Shapeupload by catching globally

### DIFF
--- a/src/main/java/de/terrestris/momo/service/GeoServerImporterService.java
+++ b/src/main/java/de/terrestris/momo/service/GeoServerImporterService.java
@@ -1,7 +1,6 @@
 package de.terrestris.momo.service;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.util.HashMap;
@@ -16,9 +15,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 
 import de.terrestris.momo.dao.GeoserverPublisherDao;
 import de.terrestris.momo.dao.MomoLayerDao;
@@ -180,16 +176,10 @@ public class GeoServerImporterService {
 	 * @param workSpaceName
 	 * @param dataStoreName
 	 * @return
-	 * @throws JsonParseException
-	 * @throws JsonMappingException
-	 * @throws URISyntaxException
-	 * @throws HttpException
-	 * @throws IOException
-	 * @throws ImporterException
+	 * @throws Exception
 	 */
 	public RESTImport createImportJob(String workSpaceName, String dataStoreName)
-			throws JsonParseException, JsonMappingException, URISyntaxException, HttpException,
-			IOException, ImporterException {
+			throws Exception {
 
 		return publisher.createImport(workSpaceName, dataStoreName);
 	}
@@ -198,16 +188,10 @@ public class GeoServerImporterService {
 	 *
 	 * @param workSpaceName
 	 * @return
-	 * @throws JsonParseException
-	 * @throws JsonMappingException
-	 * @throws URISyntaxException
-	 * @throws HttpException
-	 * @throws IOException
-	 * @throws ImporterException
+	 * @throws Exception
 	 */
 	public RESTImport createImportJob(String workSpaceName)
-			throws JsonParseException, JsonMappingException, URISyntaxException, HttpException,
-			IOException, ImporterException {
+			throws Exception {
 
 		return publisher.createImport(workSpaceName);
 	}
@@ -269,15 +253,10 @@ public class GeoServerImporterService {
 	 * @param importJobId
 	 * @param uploadFile
 	 * @return
-	 * @throws IllegalStateException
-	 * @throws IOException
-	 * @throws URISyntaxException
-	 * @throws HttpException
-	 * @throws ImporterException
+	 * @throws Exception
 	 */
 	public RESTImportTaskList uploadZipFile(Integer importJobId, MultipartFile uploadFile)
-			throws IllegalStateException, IOException, URISyntaxException, HttpException,
-			ImporterException {
+			throws Exception {
 
 		// TODO use Tempfile instead of File (e.g. for windows)
 		File file = new File("/tmp/" + uploadFile.getOriginalFilename());

--- a/src/main/java/de/terrestris/momo/service/GeoServerImporterService.java
+++ b/src/main/java/de/terrestris/momo/service/GeoServerImporterService.java
@@ -19,7 +19,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import com.jcraft.jsch.JSchException;
 
 import de.terrestris.momo.dao.GeoserverPublisherDao;
 import de.terrestris.momo.dao.MomoLayerDao;
@@ -246,16 +245,10 @@ public class GeoServerImporterService {
 	 * @param importJobId
 	 * @param taskId
 	 * @return
-	 * @throws JsonParseException
-	 * @throws JsonMappingException
-	 * @throws URISyntaxException
-	 * @throws HttpException
-	 * @throws IOException
-	 * @throws ImporterException
+	 * @throws Exception
 	 */
 	public List<RESTLayer> getRESTLayers(Integer importJobId, List<RESTImportTask> importTasks)
-			throws JsonParseException, JsonMappingException, URISyntaxException, HttpException,
-			IOException, ImporterException {
+			throws Exception {
 		return publisher.getAllImportedLayers(importJobId, importTasks);
 	}
 
@@ -264,14 +257,9 @@ public class GeoServerImporterService {
 	 * @param importJobId ID of import job
 	 * @param taskId ID of task
 	 * @return
-	 * @throws JsonParseException
-	 * @throws JsonMappingException
-	 * @throws URISyntaxException
-	 * @throws HttpException
-	 * @throws IOException
+	 * @throws Exception
 	 */
-	public RESTLayer getRESTLayer(Integer importJobId, Integer taskId) throws JsonParseException,
-			JsonMappingException, URISyntaxException, HttpException, IOException {
+	public RESTLayer getRESTLayer(Integer importJobId, Integer taskId) throws Exception {
 
 		return publisher.getLayer(importJobId, taskId);
 	}
@@ -379,20 +367,12 @@ public class GeoServerImporterService {
 	 * @param layerOpacity
 	 * @param layerHoverTemplate
 	 * @return
-	 * @throws ImporterException
-	 * @throws IOException
-	 * @throws HttpException
-	 * @throws URISyntaxException
-	 * @throws JsonMappingException
-	 * @throws JsonParseException
-	 * @throws JSchException
 	 * @throws Exception
 	 */
 	public Map<String, Object> importGeodataAndCreateLayer(MultipartFile file,
 			String fileProjection, String layerName, String layerType, String layerDescription,
 			double layerOpacity, String layerHoverTemplate)
-			throws JsonParseException, JsonMappingException, URISyntaxException, HttpException,
-			IOException, ImporterException, JSchException {
+			throws Exception {
 
 		Map<String, Object> responseMap = new HashMap<String, Object>();
 
@@ -450,20 +430,12 @@ public class GeoServerImporterService {
 	 * @param importJobId
 	 * @param importTasks
 	 * @return
-	 * @throws IOException
-	 * @throws HttpException
-	 * @throws URISyntaxException
-	 * @throws JsonMappingException
-	 * @throws JsonParseException
-	 * @throws ImporterException
-	 * @throws JSchException
 	 * @throws Exception
 	 */
 	private Map<String, Object> processTasks(String fileProjection, String layerName,
 			String layerType, String layerDescription, double layerOpacity,
 			String layerHoverTemplate, Integer importJobId, RESTImportTaskList importTasks)
-			throws JsonParseException, JsonMappingException, URISyntaxException, HttpException,
-			IOException, ImporterException, JSchException {
+			throws Exception {
 		Map<String, Object> responseMap;
 
 		for (RESTImportTask importTask : importTasks) {
@@ -505,19 +477,11 @@ public class GeoServerImporterService {
 	 * @param layerHoverTemplate
 	 * @param importJobId
 	 * @return
-	 * @throws ImporterException
-	 * @throws HttpException
-	 * @throws URISyntaxException
-	 * @throws IOException
-	 * @throws JsonMappingException
-	 * @throws JsonParseException
-	 * @throws JSchException
 	 * @throws Exception
 	 */
 	private Map<String, Object> runJobAndCreateLayer(String layerName, String layerType,
 			String layerDescription, double layerOpacity, String layerHoverTemplate,
-			Integer importJobId) throws ImporterException, URISyntaxException, HttpException,
-			JsonParseException, JsonMappingException, IOException, JSchException {
+			Integer importJobId) throws Exception {
 		try {
 			Map<String, Object> responseMap;
 			// start import job (does not depend on layerType)
@@ -526,25 +490,25 @@ public class GeoServerImporterService {
 			if (!respImp) {
 				LOG.error("Could not create layer.");
 			}
-	
+
 			// at this point will persist/return the layer of the first successful import task
 			// since addition of multiple layers is not implemented in MM admin yet.
 			RESTLayer restLayer = null;
 			RESTImportTaskList restTasks = this.getRESTTasks(importJobId);
 			for (RESTImportTask task : restTasks) {
-	
+
 				if (task.getState().equalsIgnoreCase("COMPLETE")) {
 					restLayer = this.getRESTLayer(importJobId, task.getId());
 					break;
 				}
 			}
-	
+
 			if (restLayer != null) {
 				MomoLayer layer = this.saveLayer(restLayer, layerName, layerDescription, layerOpacity,
 						layerHoverTemplate, layerType, importJobId);
-	
+
 				layerService.saveOrUpdate(layer);
-	
+
 				responseMap = ResultSet.success(layer);
 			} else {
 				responseMap = ResultSet.error("No layer of imported dataset could be imported.");
@@ -655,17 +619,12 @@ public class GeoServerImporterService {
 
 	/**
 	 * Return all import tasks for given import job
-	 * 
+	 *
 	 * @param importJobId ID of import job
 	 * @return instance of {@link RESTImportTaskList} containing all import tasks
-	 * @throws IOException
-	 * @throws HttpException
-	 * @throws URISyntaxException
-	 * @throws JsonMappingException
-	 * @throws JsonParseException
+	 * @throws Exception
 	 */
-	private RESTImportTaskList getRESTTasks(Integer importJobId) throws JsonParseException,
-			JsonMappingException, URISyntaxException, HttpException, IOException {
+	private RESTImportTaskList getRESTTasks(Integer importJobId) throws Exception {
 		return this.publisher.getRESTImportTasks(importJobId);
 	}
 
@@ -723,20 +682,12 @@ public class GeoServerImporterService {
 	 * @param taskId
 	 * @param fileProjection
 	 * @return
-	 * @throws IOException
-	 * @throws HttpException
-	 * @throws URISyntaxException
-	 * @throws JsonMappingException
-	 * @throws JsonParseException
-	 * @throws JSchException
-	 * @throws ImporterException
 	 * @throws Exception
 	 */
 	public Map<String, Object> updateCrsForImport(String layerName, String layerType,
 			String layerDescription, double layerOpacity, String layerHoverTemplate,
 			Integer importJobId, Integer taskId, String fileProjection)
-			throws JsonParseException, JsonMappingException, URISyntaxException, HttpException,
-			IOException, ImporterException, JSchException {
+			throws Exception {
 		RESTImportTask importTask = this.publisher.getRESTImportTask(importJobId, taskId);
 		this.publisher.updateSrsForRESTImportTask(importJobId, importTask, fileProjection);
 		// skip transformation as this would reproject everything to 32648, which should get

--- a/src/main/java/de/terrestris/momo/util/importer/RESTImporterPublisher.java
+++ b/src/main/java/de/terrestris/momo/util/importer/RESTImporterPublisher.java
@@ -1,7 +1,6 @@
 package de.terrestris.momo.util.importer;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -17,9 +16,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
@@ -89,7 +86,7 @@ public class RESTImporterPublisher {
 	}
 
 	/***
-	 * 
+	 *
 	 * @param importerBaseURL
 	 * @param defaultSRS
 	 * @param username
@@ -122,16 +119,10 @@ public class RESTImporterPublisher {
 	 *
 	 * @param importJob
 	 * @return
-	 * @throws HttpException
-	 * @throws URISyntaxException
-	 * @throws IOException
-	 * @throws JsonMappingException
-	 * @throws JsonParseException
-	 * @throws ImporterException
+	 * @throws Exception
 	 */
 	public RESTImport createImport(String workSpaceName, String dataStoreName)
-			throws URISyntaxException, HttpException, JsonParseException,
-			JsonMappingException, IOException, ImporterException {
+			throws Exception {
 
 		RESTImport importJob = new RESTImport();
 
@@ -169,13 +160,9 @@ public class RESTImporterPublisher {
 	 *
 	 * @param workSpaceName
 	 * @return
-	 * @throws URISyntaxException
-	 * @throws HttpException
-	 * @throws JsonParseException
-	 * @throws IOException
-	 * @throws ImporterException
+	 * @throws Exception
 	 */
-	public RESTImport createImport(String workSpaceName) throws URISyntaxException, HttpException, JsonParseException, IOException, ImporterException {
+	public RESTImport createImport(String workSpaceName) throws Exception {
 		RESTImport importJob = new RESTImport();
 
 		RESTTargetWorkspace targetWorkspace = new RESTTargetWorkspace(workSpaceName);
@@ -260,13 +247,9 @@ public class RESTImporterPublisher {
 	 * @param importJobId
 	 * @param file
 	 * @return
-	 * @throws URISyntaxException
-	 * @throws HttpException
-	 * @throws JsonParseException
-	 * @throws JsonMappingException
-	 * @throws IOException
+	 * @throws Exception
 	 */
-	public RESTImportTaskList uploadFile(Integer importJobId, File file) throws URISyntaxException, HttpException, JsonParseException, JsonMappingException, IOException {
+	public RESTImportTaskList uploadFile(Integer importJobId, File file) throws Exception {
 
 		// multipart POST
 		Response httpResponse = HttpUtil.post(
@@ -298,15 +281,10 @@ public class RESTImporterPublisher {
 	 * @param importJobId
 	 * @param taskId
 	 * @return
-	 * @throws URISyntaxException
-	 * @throws HttpException
-	 * @throws JsonParseException
-	 * @throws JsonMappingException
-	 * @throws IOException
+	 * @throws Exception
 	 */
 	public RESTImportTask getRESTImportTask(Integer importJobId, Integer taskId) throws
-		URISyntaxException, HttpException, JsonParseException,
-		JsonMappingException, IOException, Exception {
+		Exception {
 		Response httpResponse = HttpUtil.get(
 				this.addEndPoint(importJobId + "/tasks/" + taskId),
 				this.username,
@@ -320,15 +298,9 @@ public class RESTImporterPublisher {
 	 *
 	 * @param importJobId
 	 * @return
-	 * @throws URISyntaxException
-	 * @throws HttpException
-	 * @throws JsonParseException
-	 * @throws JsonMappingException
-	 * @throws IOException
+	 * @throws Exception
 	 */
-	public RESTImportTaskList getRESTImportTasks(Integer importJobId) throws
-		URISyntaxException, HttpException, JsonParseException,
-		JsonMappingException, IOException, Exception {
+	public RESTImportTaskList getRESTImportTasks(Integer importJobId) throws Exception {
 		Response httpResponse = HttpUtil.get(
 				this.addEndPoint(importJobId + "/tasks/"),
 				this.username,
@@ -366,15 +338,9 @@ public class RESTImporterPublisher {
 	 * @param importJobId
 	 * @param taskId
 	 * @return
-	 * @throws URISyntaxException
-	 * @throws HttpException
-	 * @throws JsonParseException
-	 * @throws JsonMappingException
-	 * @throws IOException
+	 * @throws Exception
 	 */
-	public RESTLayer getLayer(Integer importJobId, Integer taskId) throws
-			URISyntaxException, HttpException, JsonParseException,
-			JsonMappingException, IOException, Exception {
+	public RESTLayer getLayer(Integer importJobId, Integer taskId) throws Exception {
 
 		Response httpResponse = HttpUtil.get(
 				this.addEndPoint(importJobId + "/tasks/" + taskId + "/layer"),
@@ -390,14 +356,10 @@ public class RESTImporterPublisher {
 	 * @param importJobId
 	 * @param taskId
 	 * @return
-	 * @throws URISyntaxException
-	 * @throws HttpException
-	 * @throws JsonParseException
-	 * @throws JsonMappingException
-	 * @throws IOException
+	 * @throws Exception
 	 */
 	public RESTData getDataOfImportTask(Integer importJobId, Integer taskId)
-			throws URISyntaxException, HttpException, JsonParseException, JsonMappingException, IOException, Exception {
+			throws Exception {
 
 		final DeserializationFeature unwrapRootValueFeature = DeserializationFeature.UNWRAP_ROOT_VALUE;
 		boolean unwrapRootValueFeatureIsEnabled = mapper.isEnabled(unwrapRootValueFeature);
@@ -425,12 +387,10 @@ public class RESTImporterPublisher {
 	 * @param responseBody
 	 * @param clazz
 	 * @return
-	 * @throws IOException
-	 * @throws JsonMappingException
-	 * @throws JsonParseException
+	 * @throws Exception
 	 */
 	private AbstractRESTEntity asEntity(byte[] responseBody, Class<?> clazz)
-			throws JsonParseException, JsonMappingException, IOException, Exception  {
+			throws Exception  {
 
 		AbstractRESTEntity entity = null;
 
@@ -554,7 +514,7 @@ public class RESTImporterPublisher {
 	 * @param sourceSrs
 	 *
 	 * @return
-	 * @throws Exception 
+	 * @throws Exception
 	 */
 	public RESTLayer updateSrsForRESTImportTask(Integer importJobId, RESTImportTask importTask, String sourceSrs) throws Exception {
 		Integer taskId = importTask.getId();
@@ -578,7 +538,7 @@ public class RESTImporterPublisher {
 	 *
 	 * @param importJobId
 	 * @return
-	 * @throws Exception 
+	 * @throws Exception
 	 */
 	public List<RESTLayer> getAllImportedLayers(Integer importJobId, List<RESTImportTask> tasks) throws Exception {
 		ArrayList<RESTLayer> layers = new ArrayList<RESTLayer>();

--- a/src/main/java/de/terrestris/momo/util/importer/RESTImporterPublisher.java
+++ b/src/main/java/de/terrestris/momo/util/importer/RESTImporterPublisher.java
@@ -18,7 +18,6 @@ import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -154,11 +153,11 @@ public class RESTImporterPublisher {
 
 		try {
 			importResult = (RESTImport) this.asEntity(httpResponse.getBody(), RESTImport.class);
-		} catch (JsonMappingException jme) {
+		} catch (Exception e) {
 			if (httpResponse.getStatusCode() == HttpStatus.METHOD_NOT_ALLOWED) {
 				String msg = "Import job cannot be created, maybe the importer extension of GeoServer is not installed.";
-				LOG.debug(msg, jme);
-				throw new ImporterException(msg, jme);
+				LOG.debug(msg, e);
+				throw new ImporterException(msg, e);
 			}
 		}
 
@@ -197,11 +196,11 @@ public class RESTImporterPublisher {
 		RESTImport importResult = null;
 		try {
 			importResult = (RESTImport) this.asEntity(httpResponse.getBody(), RESTImport.class);
-		} catch (JsonMappingException jme) {
+		} catch (Exception e) {
 			if (httpResponse.getStatusCode() == HttpStatus.METHOD_NOT_ALLOWED) {
 				String msg = "Import job cannot be created, maybe the importer extension of GeoServer is not installed.";
-				LOG.debug(msg, jme);
-				throw new ImporterException(msg, jme);
+				LOG.debug(msg, e);
+				throw new ImporterException(msg, e);
 			}
 		}
 
@@ -282,7 +281,7 @@ public class RESTImporterPublisher {
 		try {
 			importTaskLists = mapper.readValue(httpResponse.getBody(), RESTImportTaskList.class);
 			LOG.info("Imported file "+ file.getName() + " contains data for multiple layers.");
-		} catch (JsonMappingException mappExcep) {
+		} catch (Exception e) {
 			LOG.info("Imported file "+ file.getName() + " likely contains data for single layer. Will check this now.");
 			RESTImportTask helperTask = mapper.readValue(httpResponse.getBody(), RESTImportTask.class);
 			if (helperTask != null) {
@@ -307,7 +306,7 @@ public class RESTImporterPublisher {
 	 */
 	public RESTImportTask getRESTImportTask(Integer importJobId, Integer taskId) throws
 		URISyntaxException, HttpException, JsonParseException,
-		JsonMappingException, IOException {
+		JsonMappingException, IOException, Exception {
 		Response httpResponse = HttpUtil.get(
 				this.addEndPoint(importJobId + "/tasks/" + taskId),
 				this.username,
@@ -329,7 +328,7 @@ public class RESTImporterPublisher {
 	 */
 	public RESTImportTaskList getRESTImportTasks(Integer importJobId) throws
 		URISyntaxException, HttpException, JsonParseException,
-		JsonMappingException, IOException {
+		JsonMappingException, IOException, Exception {
 		Response httpResponse = HttpUtil.get(
 				this.addEndPoint(importJobId + "/tasks/"),
 				this.username,
@@ -375,7 +374,7 @@ public class RESTImporterPublisher {
 	 */
 	public RESTLayer getLayer(Integer importJobId, Integer taskId) throws
 			URISyntaxException, HttpException, JsonParseException,
-			JsonMappingException, IOException {
+			JsonMappingException, IOException, Exception {
 
 		Response httpResponse = HttpUtil.get(
 				this.addEndPoint(importJobId + "/tasks/" + taskId + "/layer"),
@@ -398,7 +397,7 @@ public class RESTImporterPublisher {
 	 * @throws IOException
 	 */
 	public RESTData getDataOfImportTask(Integer importJobId, Integer taskId)
-			throws URISyntaxException, HttpException, JsonParseException, JsonMappingException, IOException {
+			throws URISyntaxException, HttpException, JsonParseException, JsonMappingException, IOException, Exception {
 
 		final DeserializationFeature unwrapRootValueFeature = DeserializationFeature.UNWRAP_ROOT_VALUE;
 		boolean unwrapRootValueFeatureIsEnabled = mapper.isEnabled(unwrapRootValueFeature);
@@ -431,7 +430,7 @@ public class RESTImporterPublisher {
 	 * @throws JsonParseException
 	 */
 	private AbstractRESTEntity asEntity(byte[] responseBody, Class<?> clazz)
-			throws JsonParseException, JsonMappingException, IOException  {
+			throws JsonParseException, JsonMappingException, IOException, Exception  {
 
 		AbstractRESTEntity entity = null;
 
@@ -451,7 +450,7 @@ public class RESTImporterPublisher {
 
 		try {
 			entityJson = this.mapper.writeValueAsString(entity);
-		} catch (JsonProcessingException e) {
+		} catch (Exception e) {
 			LOG.error("Could not parse as JSON: " + e.getMessage());
 		}
 
@@ -555,13 +554,9 @@ public class RESTImporterPublisher {
 	 * @param sourceSrs
 	 *
 	 * @return
-	 * @throws URISyntaxException
-	 * @throws JsonParseException
-	 * @throws JsonMappingException
-	 * @throws IOException
-	 * @throws HttpException
+	 * @throws Exception 
 	 */
-	public RESTLayer updateSrsForRESTImportTask(Integer importJobId, RESTImportTask importTask, String sourceSrs) throws URISyntaxException, JsonParseException, JsonMappingException, IOException, HttpException {
+	public RESTLayer updateSrsForRESTImportTask(Integer importJobId, RESTImportTask importTask, String sourceSrs) throws Exception {
 		Integer taskId = importTask.getId();
 
 		RESTLayer updatableLayer = new RESTLayer();
@@ -583,12 +578,9 @@ public class RESTImporterPublisher {
 	 *
 	 * @param importJobId
 	 * @return
-	 * @throws URISyntaxException
-	 * @throws IOException
-	 * @throws HttpException
-	 * @throws ImporterException
+	 * @throws Exception 
 	 */
-	public List<RESTLayer> getAllImportedLayers(Integer importJobId, List<RESTImportTask> tasks) throws IOException, URISyntaxException, HttpException, ImporterException {
+	public List<RESTLayer> getAllImportedLayers(Integer importJobId, List<RESTImportTask> tasks) throws Exception {
 		ArrayList<RESTLayer> layers = new ArrayList<RESTLayer>();
 		for (RESTImportTask task : tasks) {
 

--- a/src/main/java/de/terrestris/momo/web/GeoServerImporterController.java
+++ b/src/main/java/de/terrestris/momo/web/GeoServerImporterController.java
@@ -1,6 +1,5 @@
 package de.terrestris.momo.web;
 
-import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Map;
 
@@ -18,9 +17,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.jcraft.jsch.JSchException;
 
 import de.terrestris.momo.service.GeoServerImporterService;
 import de.terrestris.momo.util.importer.ImporterException;
@@ -106,7 +103,7 @@ public class GeoServerImporterController {
 					layerHoverTemplate
 			);
 
-		} catch (ImporterException | URISyntaxException | HttpException | IOException | JSchException e) {
+		} catch (Exception e) {
 			LOG.debug(e.getMessage(), e);
 			responseStatus = HttpStatus.INTERNAL_SERVER_ERROR;
 			responseMap = ResultSet.error("Could not upload the file: " + e.getMessage());
@@ -114,7 +111,7 @@ public class GeoServerImporterController {
 			// rewrite the response-Map as String
 			try {
 				responseMapAsString = mapper.writeValueAsString(responseMap);
-			} catch (JsonProcessingException e) {
+			} catch (Exception e) {
 				responseStatus = HttpStatus.INTERNAL_SERVER_ERROR;
 				LOG.error("Error while rewriting the response Map to a String" +
 						e.getMessage());
@@ -159,7 +156,7 @@ public class GeoServerImporterController {
 					layerOpacity,
 					layerHoverTemplate,
 					importJobId, taskId, fileProjection);
-		} catch (URISyntaxException | HttpException | IOException | ImporterException | JSchException e) {
+		} catch (Exception e) {
 			LOG.error("updateCrsForImport throwed an exception. Error was: " + e.getMessage());
 			responseMap = ResultSet.error("Could not upload the file: " + e.getMessage());
 		} finally {
@@ -215,7 +212,7 @@ public class GeoServerImporterController {
 		// rewrite the response-Map as String
 		try {
 			responseMapAsString = mapper.writeValueAsString(responseMap);
-		} catch (JsonProcessingException e) {
+		} catch (Exception e) {
 			responseStatus = HttpStatus.INTERNAL_SERVER_ERROR;
 			LOG.error("Error while rewriting the response Map to a String" +
 					e.getMessage());


### PR DESCRIPTION
After updating SHOGun which also updated its dependencies, the shapeupload / GeoServer importer failed on fileupload. The issue has been tracked down to a bug in the Jackson library which will be reported.
Our fix is to catch exceptions in general as in this specific usecase we received an RuntimeException instead of a JSONParseException