### PR TITLE
Configurable legend graphic (#4352)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
         <jetty.contextPath>/</jetty.contextPath>
 
-        <shogun2.version>0.1.4-SNAPSHOT</shogun2.version>
+        <shogun2.version>0.1.4</shogun2.version>
 
         <javax.jstl.version>1.2</javax.jstl.version>
 

--- a/src/main/java/de/terrestris/momo/model/MomoLayer.java
+++ b/src/main/java/de/terrestris/momo/model/MomoLayer.java
@@ -64,6 +64,13 @@ public class MomoLayer extends Layer {
 	private String metadataIdentifier;
 
 	/**
+	 * If this value IS NOT(null OR empty), it will be used as a fix legend URL
+	 * (instead of the GetLegendGraphic)
+	 */
+	private String fixLegendUrl = null;
+
+
+	/**
 	 *
 	 */
 	@OneToMany(cascade = CascadeType.REMOVE)
@@ -153,6 +160,22 @@ public class MomoLayer extends Layer {
 	}
 
 	/**
+	 * @return the fixLegendUrl
+	 */
+	public String getFixLegendUrl() {
+		return fixLegendUrl;
+	}
+
+
+	/**
+	 * @param fixLegendUrl the fixLegendUrl to set
+	 */
+	public void setFixLegendUrl(String fixLegendUrl) {
+		this.fixLegendUrl = fixLegendUrl;
+	}
+
+
+	/**
 	 * @return the owner
 	 */
 	public User getOwner() {
@@ -183,6 +206,7 @@ public class MomoLayer extends Layer {
 				append(getHoverable()).
 				append(getChartable()).
 				append(getDataType()).
+				append(getFixLegendUrl()).
 				toHashCode();
 	}
 
@@ -206,6 +230,7 @@ public class MomoLayer extends Layer {
 				append(getHoverable(), other.getHoverable()).
 				append(getChartable(), other.getChartable()).
 				append(getDataType(), other.getDataType()).
+				append(getFixLegendUrl(), other.getFixLegendUrl()).
 				isEquals();
 	}
 

--- a/src/main/java/de/terrestris/momo/service/SldService.java
+++ b/src/main/java/de/terrestris/momo/service/SldService.java
@@ -1,16 +1,27 @@
 package de.terrestris.momo.service;
 
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.http.HttpException;
+import org.apache.http.entity.ContentType;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import de.terrestris.momo.dao.GeoserverPublisherDao;
 import de.terrestris.momo.dao.GeoserverReaderDao;
 import de.terrestris.momo.dao.MomoLayerDao;
 import de.terrestris.momo.model.MomoLayer;
 import de.terrestris.shogun2.model.layer.source.TileWmsLayerDataSource;
+import de.terrestris.shogun2.util.http.HttpUtil;
+import de.terrestris.shogun2.util.model.Response;
 import it.geosolutions.geoserver.rest.decoder.RESTLayer;
 import javassist.NotFoundException;
 
@@ -38,11 +49,54 @@ public class SldService {
 	@Qualifier("momoLayerService")
 	private MomoLayerService<MomoLayer, MomoLayerDao<MomoLayer>> momoLayerService;
 
+	/**
+	 *
+	 */
+	@Value("${geoserver.baseUrl}")
+	private String geoServerBaseUrl;
+
+	/**
+	 *
+	 */
+	@Value("${geoserver.username}")
+	private String gsuser;
+
+	/**
+	 *
+	 */
+	@Value("${geoserver.password}")
+	private String gspassword;
+
+
 	@PreAuthorize("hasRole(@configHolder.getSuperAdminRoleName()) or "
 			+ "hasPermission(#layerId, 'de.terrestris.momo.model.MomoLayer', 'UPDATE')")
 	public void updateSld(Integer layerId, String sldName, String sld) throws Exception {
 		LOG.info("Updating " + sldName);
 
+		String gsDefaultStyle = null;
+
+		try {
+			gsDefaultStyle = this.getDefaultStyleForLayer(layerId);
+		} catch (Exception e) {
+			LOG.error("Error while getting default style for layer: " + e.getMessage());
+		}
+
+		if (!gsDefaultStyle.equalsIgnoreCase(sldName)) {
+			String msg = "Layer styles do not match!";
+			LOG.error(msg);
+			throw new Exception(msg);
+		}
+
+		geoserverPublisherDao.updateStyle(sld, sldName);
+	}
+
+	/**
+	 *
+	 * @param layerId
+	 * @return
+	 * @throws NotFoundException
+	 */
+	private String getDefaultStyleForLayer(Integer layerId) throws NotFoundException {
 		MomoLayer layer = momoLayerService.findById(layerId);
 
 		if (layer == null) {
@@ -51,7 +105,6 @@ public class SldService {
 			throw new NotFoundException(msg);
 		}
 		String layerName = null;
-
 		String layerSourceType = layer.getSource().getType();
 
 		if (layerSourceType.equalsIgnoreCase("TileWMS")) {
@@ -67,15 +120,68 @@ public class SldService {
 
 		RESTLayer gsLayer = geoserverReaderDao.getLayer(layerName.split(":")[0], layerName.split(":")[1]);
 
-		String gsDefaultStyle = gsLayer.getDefaultStyle();
+		return gsLayer.getDefaultStyle();
+	}
 
-		if (!gsDefaultStyle.equalsIgnoreCase(sldName)) {
-			String msg = "Layer styles do not match!";
-			LOG.error(msg);
-			throw new Exception(msg);
+	/**
+	 *
+	 * @param layerId
+	 * @param height
+	 * @param width
+	 * @param imgUrl
+	 * @param format
+	 * @return
+	 * @throws NotFoundException
+	 * @throws URISyntaxException
+	 * @throws HttpException
+	 */
+	@PreAuthorize("hasRole(@configHolder.getSuperAdminRoleName()) or "
+			+ "hasPermission(#layerId, 'de.terrestris.momo.model.MomoLayer', 'UPDATE')")
+	public Response updateLegendSrc(Integer layerId, Integer width, Integer height, String imgUrl, String format) throws NotFoundException, URISyntaxException, HttpException {
+
+		String gsDefaultStyle = null;
+
+		try {
+			gsDefaultStyle = this.getDefaultStyleForLayer(layerId);
+		} catch (Exception e) {
+			LOG.error("Error while getting default style for layer: " + e.getMessage());
 		}
 
-		geoserverPublisherDao.updateStyle(sld, sldName);
+		try {
+
+			// TODO move this to properties file
+			imgUrl = "http://momo-shogun:8080/momo" + imgUrl;
+			// fix to avoid "not supported format" error in GeoServer since a check against a valid
+			// image extension will be performed by PUTting
+			// s. https://github.com/geoserver/geoserver/blob/22e3c7a2adc3bd5f40cf9a675081e32a95e37fa7/src/web/wms/src/main/java/org/geoserver/wms/web/data/ExternalGraphicPanel.java#L100
+			imgUrl += "&format=.";
+			imgUrl += format.split("/")[1];
+
+			Map<String, Object> legendMap = new HashMap<>();
+			Map<String, Map<String, Object>> resultMap = new HashMap<>();
+			Map<String, Object> styleMap = new HashMap<>();
+			legendMap.put("format", format);
+			legendMap.put("height", height);
+			legendMap.put("width", width);
+			legendMap.put("onlineResource", imgUrl);
+
+			styleMap.put("legend", legendMap);
+			resultMap.put("style", styleMap);
+
+			ObjectMapper mapperObj = new ObjectMapper();
+			String legendSrcJson = null;
+			legendSrcJson = mapperObj.writeValueAsString(resultMap);
+
+			String url = geoServerBaseUrl.split("/momo/ows")[0] + "/rest/styles/" + gsDefaultStyle;
+			LOG.info("Start updating legend source...");
+
+			return HttpUtil.put(url, legendSrcJson, ContentType.APPLICATION_JSON, gsuser, gspassword);
+
+		} catch (Exception e) {
+			LOG.error("Could not update legend source for layer: " + e.getMessage());
+			return null;
+		}
+
 	}
 
 }

--- a/src/main/java/de/terrestris/momo/util/serializer/MomoLayerSerializer.java
+++ b/src/main/java/de/terrestris/momo/util/serializer/MomoLayerSerializer.java
@@ -77,6 +77,7 @@ public class MomoLayerSerializer extends StdSerializer<MomoLayer>{
 		generator.writeBooleanField("hoverable", momoLayer.getHoverable() != null ? momoLayer.getHoverable() : false);
 		generator.writeStringField("metadataIdentifier", momoLayer.getMetadataIdentifier() != null ? momoLayer.getMetadataIdentifier() : StringUtils.EMPTY);
 		generator.writeStringField("name", momoLayer.getName());
+		generator.writeStringField("fixLegendUrl", momoLayer.getFixLegendUrl());
 		generator.writeBooleanField("spatiallyRestricted", momoLayer.getSpatiallyRestricted() != null ? momoLayer.getSpatiallyRestricted() : false);
 		generator.writeObjectField("appearance", momoLayer.getAppearance());
 		generator.writeObjectField("owner", momoLayer.getOwner());

--- a/src/main/java/de/terrestris/momo/web/MomoImageFileController.java
+++ b/src/main/java/de/terrestris/momo/web/MomoImageFileController.java
@@ -87,7 +87,7 @@ public class MomoImageFileController<E extends ImageFile, D extends ImageFileDao
 	public ResponseEntity<?> getThumbnail(@RequestParam Integer id) {
 
 		final HttpHeaders responseHeaders = new HttpHeaders();
-		Map<String, Object> responseMap = new HashMap<String, Object>();
+		Map<String, Object> responseMap = new HashMap<>();
 
 		try {
 			// try to get the image
@@ -106,7 +106,7 @@ public class MomoImageFileController<E extends ImageFile, D extends ImageFileDao
 			LOG.info("Successfully got the image thumbnail " +
 					image.getFileName());
 
-			return new ResponseEntity<byte[]>(
+			return new ResponseEntity<>(
 					imageBytes, responseHeaders, HttpStatus.OK);
 		} catch (Exception e) {
 			final String errorMessage = "Could not get the image thumbnail: "
@@ -117,7 +117,54 @@ public class MomoImageFileController<E extends ImageFile, D extends ImageFileDao
 
 			responseHeaders.setContentType(MediaType.APPLICATION_JSON);
 
-			return new ResponseEntity<Map<String, Object>>(
+			return new ResponseEntity<>(
+					responseMap, responseHeaders, HttpStatus.OK);
+		}
+	}
+
+
+	/**
+	 * Gets a file from the database by the given id
+	 *
+	 * @return
+	 * @throws SQLException
+	 */
+	@Override
+	@RequestMapping(value = "/get.action", method=RequestMethod.GET)
+	public ResponseEntity<?> getFile(@RequestParam Integer id) {
+
+		final HttpHeaders responseHeaders = new HttpHeaders();
+		Map<String, Object> responseMap = new HashMap<>();
+
+		try {
+			// try to get the image
+			ImageFile image = service.getDao().findById(id);
+			if(image == null) {
+				throw new Exception("Could not find the image with id " + id);
+			}
+
+			byte[] imageBytes = null;
+
+			imageBytes = image.getFile();
+
+			responseHeaders.setContentType(
+					MediaType.parseMediaType(image.getFileType()));
+
+			LOG.info("Successfully got the image " +
+					image.getFileName());
+
+			return new ResponseEntity<>(
+					imageBytes, responseHeaders, HttpStatus.OK);
+		} catch (Exception e) {
+			final String errorMessage = "Could not get the image: "
+					+ e.getMessage();
+
+			LOG.error(errorMessage);
+			responseMap = ResultSet.error(errorMessage);
+
+			responseHeaders.setContentType(MediaType.APPLICATION_JSON);
+
+			return new ResponseEntity<>(
 					responseMap, responseHeaders, HttpStatus.OK);
 		}
 	}

--- a/src/main/java/de/terrestris/momo/web/SldController.java
+++ b/src/main/java/de/terrestris/momo/web/SldController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 import de.terrestris.momo.service.SldService;
 import de.terrestris.shogun2.util.data.ResultSet;
+import de.terrestris.shogun2.util.model.Response;
 
 /**
  *
@@ -33,11 +34,19 @@ public class SldController {
 	@Qualifier("sldService")
 	private SldService sldService;
 
+	/**
+	 *
+	 * @param sldName
+	 * @param sld
+	 * @param layerId
+	 * @return
+	 */
 	@RequestMapping(value = "/update.action", method = {RequestMethod.POST})
 	public @ResponseBody Map<String, Object> updateSld(
 			@RequestParam String sldName,
 			@RequestParam String sld,
 			@RequestParam Integer layerId) {
+
 		try {
 			this.sldService.updateSld(layerId, sldName, sld);
 			LOG.debug("Updated Sld " + sldName);
@@ -45,6 +54,33 @@ public class SldController {
 		} catch (Exception e) {
 			LOG.error("Error while updating Sld: " + e.getMessage());
 			return ResultSet.error("Error while updating Sld: " + e.getMessage());
+		}
+	}
+
+	/**
+	 *
+	 * @param layerId
+	 * @param width
+	 * @param height
+	 * @param imgUrl
+	 * @param format
+	 * @return
+	 */
+	@RequestMapping(value = "/updateLegendSrc.action", method = {RequestMethod.POST})
+	public @ResponseBody Map<String, Object> updateLegendSrc(
+			@RequestParam Integer layerId,
+			@RequestParam Integer width,
+			@RequestParam Integer height,
+			@RequestParam String imgUrl,
+			@RequestParam String format) {
+
+		try {
+			Response response = this.sldService.updateLegendSrc(layerId, width, height, imgUrl, format);
+			LOG.debug("Successfully updated legend source");
+			return ResultSet.success(response.getBody());
+		} catch (Exception e) {
+			LOG.error("Error while updating legend source: " + e.getMessage());
+			return ResultSet.error("Error while updating legend source: " + e.getMessage());
 		}
 	}
 

--- a/src/main/resources/META-INF/locale/admin.csv
+++ b/src/main/resources/META-INF/locale/admin.csv
@@ -344,6 +344,9 @@ MoMo.admin.view.tab.CreateOrEditLayer;config.data.i18n.general.uploadSkippedGeoT
 MoMo.admin.view.tab.CreateOrEditLayer;config.data.i18n.general.uploadInfoGeoreferencedGeoTiffMsg;Daten sind georeferenziert;Data is georeferenced;Өгөгдөлд гео-лавлагаа хийсэн; -
 MoMo.admin.view.tab.CreateOrEditLayer;config.data.i18n.general.uploadGeoTiffNotGeoreferencedMsg;Ihre Rasterdaten sind nicht korrekt georeferenziert. Bitte fügen Sie eine Worldfile (*.tfw) in die ZIP-Datei, georeferenzieren Sie das GeoTIFF oder wählen Sie ein Koordinatensystem aus.;Your raster data is not georeferenced. Please georeference it, add a worldfile (*.tfw) to the zip or select one in the combo box below.;Таны растер мэдээлэл гео-лавлагаанд байна. Үүнийг нэг бол гео-лавлагаанд оруулна уу эсвэл зип дээр word-ийн файл (*.tfw) болгож нэмнэ үү; -
 MoMo.admin.view.tab.CreateOrEditLayer;config.data.i18n.general.uploadFailedNoTypeDeterminedMsg;Der Typ des Layers kann nicht bestimmt werden.;Type of the layer could not be determined.;Давхаргын төрлийг тодорхойлж чадсангүй; -
+MoMo.admin.view.tab.CreateOrEditLayer;config.data.i18n.general.legend.title;Legenden-Einstellungen;Legend settings;_MN_TEXT_PLACEHOLDER; -
+MoMo.admin.view.tab.CreateOrEditLayer;config.data.i18n.general.legend.useFixLegendUrlCbBoxLabel;Festes Legendenbild (statt GetLegendGraphic)?;Fix legend image (instead of GetLegendGraphic)?;_MN_TEXT_PLACEHOLDER; -
+MoMo.admin.view.tab.CreateOrEditLayer;config.data.i18n.general.legend.chooseOrUploadImage;Bild hochladen/auswählen;Upload/choose image;_MN_TEXT_PLACEHOLDER; -
 MoMo.admin.view.tab.CreateOrEditLayer;config.data.i18n.metadata.tabPanelTitle;Metadaten;Metadata;Мета-өгөгдөл; -
 MoMo.admin.view.tab.CreateOrEditLayer;config.data.i18n.metadata.uploadText;Metadaten XML hochladen;Upload Metadata XML;Upload Metadata XML; -
 MoMo.admin.view.tab.CreateOrEditLayer;config.data.i18n.metadata.downloadText;Metadaten herunterladen;Download Metadata;Download Metadata; -

--- a/src/main/resources/META-INF/spring/momo-context-security.xml
+++ b/src/main/resources/META-INF/spring/momo-context-security.xml
@@ -25,7 +25,7 @@
     <http pattern="/userdocs/**" security="none" />
     <!-- images need to be retrieved by the geoserver due to externalgraphics
         in the sldstyler, so we need to remove the csrf security enhancement -->
-    <http pattern="/momoimage/getThumbnail.action" security="none" />
+    <http pattern="/momoimage/**" security="none" />
 
     <!-- Remove security for print requests, where we cannot include csrf tokens -->
     <http pattern="/print/**" security="none" />


### PR DESCRIPTION
Introduced legend graphic configuration for layer.

If config is checked, user has the possibillity to upload his own image to be used instead of default legendGraphic image generated from SLD assigned to layer.

Frontend counterparts:
*  https://github.com/terrestris/momo3-admin/pull/7
*  https://github.com/terrestris/momo3-frontend/pull/77

Please review @weskamm 